### PR TITLE
Add multi-cover selection and upload support

### DIFF
--- a/__tests__/media-image-records.test.ts
+++ b/__tests__/media-image-records.test.ts
@@ -1,0 +1,40 @@
+import { resolveAndPersistImageList } from 'lib/media-storage/media-image-records';
+import { persistExternalImageToS3 } from 'lib/media-storage/local-image-storage';
+
+jest.mock('lib/media-storage/local-image-storage', () => ({
+  persistExternalImageToS3: jest.fn(),
+}));
+
+describe('resolveAndPersistImageList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('accepts string and object URL payloads and reports invalid payloads', async () => {
+    const mockedPersistExternalImageToS3 = persistExternalImageToS3 as jest.Mock;
+    mockedPersistExternalImageToS3.mockImplementation(async ({ sourceUrl }) => ({
+      publicPath: sourceUrl,
+      mimeType: 'image/png',
+      sizeBytes: 100,
+      sourceUrl,
+    }));
+
+    const response = await resolveAndPersistImageList(
+      { mediaType: 'book', mediaId: 'book-1' },
+      [
+        'https://example.com/cover-1.png',
+        { url: 'https://example.com/cover-2.png' },
+        { src: 'https://example.com/cover-3.png' },
+        { image: 'invalid' },
+      ],
+    );
+
+    expect(response.images).toHaveLength(3);
+    expect(response.failures).toEqual([
+      {
+        sourceUrl: '',
+        message: 'Invalid image payload. Expected an image URL string.',
+      },
+    ]);
+  });
+});

--- a/__tests__/mediacollector/png-export-images.test.ts
+++ b/__tests__/mediacollector/png-export-images.test.ts
@@ -1,0 +1,124 @@
+import {
+  buildPNGExportImages,
+  type PNGExportImage,
+} from '@/mediacollector/png-export-images';
+import type { CollectorFormData } from '@/mediacollector/collector-form/collectorFormSchema';
+
+type CollectedBlock = CollectorFormData['collectedData'][number];
+
+function createBlock(overrides: Partial<CollectedBlock> = {}): CollectedBlock {
+  return {
+    type: 'book',
+    images: [
+      {
+        url: 'https://img/default.png',
+        selected: true,
+        isDefault: true,
+        spineColor: '#111111',
+      },
+    ],
+    blockInfo: {
+      title: 'Dune',
+      author: 'Frank Herbert',
+      pubYear: 1965,
+      pageCount: 412,
+      spineColor: '#111111',
+      genres: [],
+    },
+    blockID: 'BLK-1',
+    isDatabase: false,
+    ...overrides,
+  };
+}
+
+describe('buildPNGExportImages', () => {
+  test('uses selected image for database blocks instead of the default image', () => {
+    const images = buildPNGExportImages([
+      createBlock({
+        isDatabase: true,
+        images: [
+          {
+            url: 'https://img/default.png',
+            selected: false,
+            isDefault: true,
+            spineColor: '#111111',
+          },
+          {
+            url: 'https://img/selected.png',
+            selected: true,
+            isDefault: false,
+            spineColor: '#222222',
+          },
+        ],
+      }),
+    ]);
+
+    expect(images).toEqual<PNGExportImage[]>([
+      {
+        url: 'https://img/selected.png',
+        type: 'book',
+        spineColor: '#222222',
+      },
+    ]);
+  });
+
+  test('uses selected image for newly collected blocks', () => {
+    const images = buildPNGExportImages([
+      createBlock({
+        isDatabase: false,
+        type: 'movie',
+        images: [
+          {
+            url: 'https://img/default.png',
+            selected: false,
+            isDefault: true,
+            spineColor: '#111111',
+          },
+          {
+            url: 'https://img/selected.png',
+            selected: true,
+            isDefault: false,
+            spineColor: '#333333',
+          },
+        ],
+      }),
+    ]);
+
+    expect(images).toEqual<PNGExportImage[]>([
+      {
+        url: 'https://img/selected.png',
+        type: 'movie',
+        spineColor: '#333333',
+      },
+    ]);
+  });
+
+  test('falls back to the default image when no image is selected', () => {
+    const images = buildPNGExportImages([
+      createBlock({
+        images: [
+          {
+            url: 'https://img/first.png',
+            selected: false,
+            isDefault: false,
+            spineColor: '#111111',
+          },
+          {
+            url: 'https://img/default.png',
+            selected: false,
+            isDefault: true,
+            spineColor: '#444444',
+          },
+        ],
+      }),
+    ]);
+
+    expect(images).toEqual<PNGExportImage[]>([
+      {
+        url: 'https://img/default.png',
+        type: 'book',
+        spineColor: '#444444',
+      },
+    ]);
+  });
+});

--- a/__tests__/trpc/collect.router.test.ts
+++ b/__tests__/trpc/collect.router.test.ts
@@ -2,6 +2,7 @@ import { collectRouter } from 'lib/trpc/routers/collect/_';
 import { getMediaCovers } from 'lib/trpc/routers/collect/actions/get-media-covers';
 import { getOpenLibraryData } from 'lib/trpc/routers/collect/actions/get-open-library-data';
 import { searchByTitle } from 'lib/trpc/routers/database/actions/search-by-title';
+import { persistUploadedImageToS3 } from 'lib/media-storage/local-image-storage';
 
 jest.mock('lib/trpc/routers/collect/actions/get-media-covers', () => ({
   getMediaCovers: jest.fn(),
@@ -15,7 +16,64 @@ jest.mock('lib/trpc/routers/database/actions/search-by-title', () => ({
   searchByTitle: jest.fn(),
 }));
 
+jest.mock('lib/media-storage/local-image-storage', () => ({
+  persistUploadedImageToS3: jest.fn(),
+}));
+
 describe('collect router', () => {
+  test('uploadCoverImage returns persisted URL', async () => {
+    const mockedPersistUploadedImageToS3 = persistUploadedImageToS3 as jest.Mock;
+    mockedPersistUploadedImageToS3.mockResolvedValueOnce({
+      publicPath: 'https://cdn.example.com/uploaded.png',
+      mimeType: 'image/png',
+      sizeBytes: 10,
+      sourceUrl: 'cover.png',
+    });
+
+    const caller = collectRouter.createCaller({
+      db: {},
+      authSession: { user: { id: '1', role: 'admin' } },
+      user: { id: '1', role: 'admin' },
+    } as never);
+
+    const response = await caller.uploadCoverImage({
+      blockID: 'BLK-1',
+      sortOrder: 3,
+      fileName: 'cover.png',
+      mimeType: 'image/png',
+      dataBase64: Buffer.from('file-bytes').toString('base64'),
+    });
+
+    expect(response).toEqual({ url: 'https://cdn.example.com/uploaded.png' });
+    expect(mockedPersistUploadedImageToS3).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaType: 'book',
+        mediaId: 'BLK-1',
+        sortOrder: 3,
+      }),
+    );
+  });
+
+  test('uploadCoverImage rejects empty payload', async () => {
+    const caller = collectRouter.createCaller({
+      db: {},
+      authSession: { user: { id: '1', role: 'admin' } },
+      user: { id: '1', role: 'admin' },
+    } as never);
+
+    await expect(
+      caller.uploadCoverImage({
+        blockID: 'BLK-1',
+        sortOrder: 0,
+        fileName: 'cover.png',
+        mimeType: 'image/png',
+        dataBase64: '',
+      }),
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+  });
+
   test('collectMedia returns database book block with resolved genres', async () => {
     const mockedSearchByTitle = searchByTitle as jest.Mock;
     mockedSearchByTitle.mockResolvedValueOnce({

--- a/__tests__/trpc/collect.router.test.ts
+++ b/__tests__/trpc/collect.router.test.ts
@@ -44,7 +44,12 @@ describe('collect router', () => {
       dataBase64: Buffer.from('file-bytes').toString('base64'),
     });
 
-    expect(response).toEqual({ url: 'https://cdn.example.com/uploaded.png' });
+    expect(response).toEqual({
+      url: 'https://cdn.example.com/uploaded.png',
+      isDefault: false,
+      spineColor: '#ffffff',
+      selected: true,
+    });
     expect(mockedPersistUploadedImageToS3).toHaveBeenCalledWith(
       expect.objectContaining({
         mediaType: 'book',
@@ -86,7 +91,14 @@ describe('collect router', () => {
           pageCount: 412,
           pubYear: 1965,
           spineColor: '#fff',
-          imageUrls: ['https://img/book-1.png'],
+          images: [
+            {
+              url: 'https://img/book-1.png',
+              isDefault: true,
+              spineColor: '#fff',
+              selected: false,
+            },
+          ],
         },
       ],
     });

--- a/__tests__/trpc/database.router.test.ts
+++ b/__tests__/trpc/database.router.test.ts
@@ -1,7 +1,7 @@
 import { databaseRouter } from 'lib/trpc/routers/database/_';
 import { searchByTitle } from 'lib/trpc/routers/database/actions/search-by-title';
 import {
-  loadBookImageUrlsById,
+  loadBookImagesById,
   replaceBookImageRecords,
   replaceOtherMediaImageRecords,
   resolveAndPersistImageList,
@@ -11,6 +11,8 @@ jest.mock('lib/trpc/routers/database/actions/search-by-title', () => ({
   searchByTitle: jest.fn(),
 }));
 jest.mock('lib/media-storage/media-image-records', () => ({
+  loadBookImagesById: jest.fn().mockResolvedValue(new Map()),
+  loadOtherMediaImagesById: jest.fn().mockResolvedValue(new Map()),
   loadBookImageUrlsById: jest.fn().mockResolvedValue(new Map()),
   loadOtherMediaImageUrlsById: jest.fn().mockResolvedValue(new Map()),
   replaceBookImageRecords: jest.fn().mockResolvedValue(undefined),
@@ -30,15 +32,21 @@ describe('database router', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (resolveAndPersistImageList as jest.Mock).mockImplementation(
-      async (_mediaReference: unknown, sourceImageUrls: string[]) => ({
-        images: sourceImageUrls.map((sourceUrl) => ({
-          publicPath: sourceUrl.startsWith('http')
-            ? `/uploads/covers/2026/03/${sourceUrl.split('/').pop()}`
-            : sourceUrl,
-          mimeType: 'image/png',
-          sizeBytes: 1024,
-          sourceUrl,
-        })),
+      async (_mediaReference: unknown, sourceImages: Array<string | { url: string }>) => ({
+        images: sourceImages.map((sourceImage, index) => {
+          const sourceUrl =
+            typeof sourceImage === 'string' ? sourceImage : sourceImage.url;
+          return {
+            publicPath: sourceUrl.startsWith('http')
+              ? `/uploads/covers/2026/03/${sourceUrl.split('/').pop()}`
+              : sourceUrl,
+            mimeType: 'image/png',
+            sizeBytes: 1024,
+            sourceUrl,
+            isDefault: index === 0,
+            spineColor: '#ffffff',
+          };
+        }),
         failures: [],
       }),
     );
@@ -72,7 +80,7 @@ describe('database router', () => {
         pageCount: 412,
         pubYear: 1965,
         spineColor: '#fff',
-        imageUrls: ['https://img'],
+        images: [],
         mediaType: 'book',
       },
     ];
@@ -122,7 +130,7 @@ describe('database router', () => {
       paginatedList: [
         {
           ...rows[0],
-          imageUrls: [],
+          images: [],
         },
       ],
       total: 1,
@@ -210,7 +218,7 @@ describe('database router', () => {
         id: 'missing-id',
         title: 'Nope',
         spineColor: '#000',
-        imageUrls: ['https://img'],
+        images: [{ url: 'https://img', isDefault: true, spineColor: '#000' }],
       },
     });
 
@@ -221,7 +229,7 @@ describe('database router', () => {
         id: 'missing-id',
         title: 'Nope',
         spineColor: '#000',
-        imageUrls: ['https://img'],
+        images: [{ url: 'https://img', isDefault: true, spineColor: '#000' }],
       },
       type: 'movie',
       errors: ['Nope does not exist in the database.'],
@@ -238,7 +246,7 @@ describe('database router', () => {
               mediaType: 'movie',
               title: 'Matrix',
               spineColor: '#ffffff',
-              imageUrls: [],
+              images: [],
             },
           ]),
         })),
@@ -252,7 +260,13 @@ describe('database router', () => {
                 mediaType: 'movie',
                 title: 'Matrix',
                 spineColor: '#ffffff',
-                imageUrls: ['/uploads/covers/2026/03/selected.png'],
+                images: [
+                  {
+                    url: '/uploads/covers/2026/03/selected.png',
+                    isDefault: true,
+                    spineColor: '#ffffff',
+                  },
+                ],
               },
             ]),
           })),
@@ -268,8 +282,18 @@ describe('database router', () => {
         blockID: 'BLK-1',
         isDatabase: false,
         images: [
-          { url: 'https://img/selected.png', selected: true },
-          { url: 'https://img/unselected.png', selected: false },
+          {
+            url: 'https://img/selected.png',
+            selected: true,
+            isDefault: true,
+            spineColor: '#ffffff',
+          },
+          {
+            url: 'https://img/unselected.png',
+            selected: false,
+            isDefault: false,
+            spineColor: '#ffffff',
+          },
         ],
         blockInfo: {
           title: 'Matrix',
@@ -287,7 +311,14 @@ describe('database router', () => {
           mediaType: 'movie',
           title: 'Matrix',
           spineColor: '#ffffff',
-          imageUrls: ['/uploads/covers/2026/03/selected.png'],
+          images: [
+            {
+              url: '/uploads/covers/2026/03/selected.png',
+              isDefault: true,
+              spineColor: '#ffffff',
+              selected: false,
+            },
+          ],
           blockID: 'BLK-1',
         },
         type: 'movie',
@@ -310,7 +341,13 @@ describe('database router', () => {
                 pageCount: 412,
                 pubYear: 1965,
                 spineColor: '#fff',
-                imageUrls: ['/uploads/covers/2026/03/old-cover.png'],
+                images: [
+                  {
+                    url: '/uploads/covers/2026/03/old-cover.png',
+                    isDefault: true,
+                    spineColor: '#fff',
+                  },
+                ],
               },
             ]),
           })),
@@ -328,7 +365,13 @@ describe('database router', () => {
                   pageCount: 412,
                   pubYear: 1965,
                   spineColor: '#fff',
-                  imageUrls: ['/uploads/covers/2026/03/cover.png'],
+                  images: [
+                    {
+                      url: '/uploads/covers/2026/03/cover.png',
+                      isDefault: true,
+                      spineColor: '#fff',
+                    },
+                  ],
                 },
               ]),
             })),
@@ -346,7 +389,13 @@ describe('database router', () => {
         pageCount: 412,
         pubYear: 1965,
         spineColor: '#fff',
-        imageUrls: ['https://images.example.com/cover.png'],
+        images: [
+          {
+            url: 'https://images.example.com/cover.png',
+            isDefault: true,
+            spineColor: '#fff',
+          },
+        ],
       },
     });
 
@@ -355,7 +404,13 @@ describe('database router', () => {
       message: 'Dune successfully edited.',
       actionAttemptItem: {
         id: 'book-1',
-        imageUrls: ['/uploads/covers/2026/03/cover.png'],
+        images: [
+          {
+            url: '/uploads/covers/2026/03/cover.png',
+            isDefault: true,
+            spineColor: '#ffffff',
+          },
+        ],
       },
     });
     expect(resolveAndPersistImageList).toHaveBeenCalled();
@@ -382,7 +437,7 @@ describe('database router', () => {
               mediaType: 'movie',
               title: 'Matrix',
               spineColor: '#ffffff',
-              imageUrls: [],
+              images: [],
             },
           ]),
         })),
@@ -400,7 +455,14 @@ describe('database router', () => {
         type: 'movie',
         blockID: 'BLK-1',
         isDatabase: false,
-        images: [{ url: 'https://img/selected.png', selected: true }],
+        images: [
+          {
+            url: 'https://img/selected.png',
+            selected: true,
+            isDefault: true,
+            spineColor: '#ffffff',
+          },
+        ],
         blockInfo: {
           title: 'Matrix',
           spineColor: '#ffffff',
@@ -446,7 +508,13 @@ describe('database router', () => {
                 pageCount: 412,
                 pubYear: 1965,
                 spineColor: '#fff',
-                imageUrls: ['/uploads/covers/2026/03/old-cover.png'],
+                images: [
+                  {
+                    url: '/uploads/covers/2026/03/old-cover.png',
+                    isDefault: true,
+                    spineColor: '#fff',
+                  },
+                ],
               },
             ]),
           })),
@@ -465,7 +533,13 @@ describe('database router', () => {
         pageCount: 412,
         pubYear: 1965,
         spineColor: '#fff',
-        imageUrls: ['https://images.example.com/cover.png'],
+        images: [
+          {
+            url: 'https://images.example.com/cover.png',
+            isDefault: true,
+            spineColor: '#fff',
+          },
+        ],
       },
     });
 
@@ -482,8 +556,20 @@ describe('database router', () => {
   });
 
   test('getPaginated uses normalized image records when available', async () => {
-    (loadBookImageUrlsById as jest.Mock).mockResolvedValueOnce(
-      new Map([['book-1', ['/uploads/covers/2026/03/book-1.png']]]),
+    (loadBookImagesById as jest.Mock).mockResolvedValueOnce(
+      new Map([
+        [
+          'book-1',
+          [
+            {
+              url: '/uploads/covers/2026/03/book-1.png',
+              isDefault: true,
+              spineColor: '#fff',
+              selected: false,
+            },
+          ],
+        ],
+      ]),
     );
 
     const rows = [
@@ -494,7 +580,7 @@ describe('database router', () => {
         pageCount: 412,
         pubYear: 1965,
         spineColor: '#fff',
-        imageUrls: ['https://legacy-url.example.com/image.png'],
+        images: [],
         mediaType: 'book',
       },
     ];
@@ -542,8 +628,13 @@ describe('database router', () => {
       genre: '',
     });
 
-    expect(response.paginatedList[0]?.imageUrls).toEqual([
-      '/uploads/covers/2026/03/book-1.png',
+    expect(response.paginatedList[0]?.images).toEqual([
+      {
+        url: '/uploads/covers/2026/03/book-1.png',
+        isDefault: true,
+        spineColor: '#fff',
+        selected: false,
+      },
     ]);
   });
 });

--- a/__tests__/trpc/genres.router.test.ts
+++ b/__tests__/trpc/genres.router.test.ts
@@ -1,8 +1,8 @@
 import { genresRouter } from '../../lib/trpc/routers/genres/_';
-import { loadBookImageUrlsById } from 'lib/media-storage/media-image-records';
+import { loadBookImagesById } from 'lib/media-storage/media-image-records';
 
 jest.mock('lib/media-storage/media-image-records', () => ({
-  loadBookImageUrlsById: jest.fn(),
+  loadBookImagesById: jest.fn(),
 }));
 
 function createAdminCaller(db: unknown) {
@@ -16,7 +16,7 @@ function createAdminCaller(db: unknown) {
 describe('genres router', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (loadBookImageUrlsById as jest.Mock).mockResolvedValue(new Map());
+    (loadBookImagesById as jest.Mock).mockResolvedValue(new Map());
   });
 
   test('getAll returns full genre list', async () => {
@@ -160,7 +160,7 @@ describe('genres router', () => {
 
     expect(response).toEqual({
       message: 'Successful database gather',
-      paginatedList: [{ id: 'book-1', title: 'Dune', imageUrls: [] }],
+      paginatedList: [{ id: 'book-1', title: 'Dune', images: [] }],
       total: 1,
     });
   });
@@ -205,7 +205,7 @@ describe('genres router', () => {
 
     expect(response).toEqual({
       message: 'Successful database gather',
-      paginatedList: [{ id: 'book-2', title: 'Standalone', imageUrls: [] }],
+      paginatedList: [{ id: 'book-2', title: 'Standalone', images: [] }],
       total: 1,
     });
   });

--- a/__tests__/ui/cbbimages-fallback.test.tsx
+++ b/__tests__/ui/cbbimages-fallback.test.tsx
@@ -49,7 +49,14 @@ function CBBImagesTestHarness() {
       collectedData: [
         {
           type: 'book',
-          images: [{ url: '/uploads/covers/2026/03/example.png', selected: true }],
+          images: [
+            {
+              url: '/uploads/covers/2026/03/example.png',
+              selected: true,
+              isDefault: true,
+              spineColor: '#ffffff',
+            },
+          ],
           blockInfo: {
             title: 'Dune',
             author: 'Frank Herbert',

--- a/__tests__/ui/cbbimages-fallback.test.tsx
+++ b/__tests__/ui/cbbimages-fallback.test.tsx
@@ -5,6 +5,20 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import CBBImages from '@/mediacollector/CBBImages';
 import type { CollectorFormData } from '@/mediacollector/collector-form/collectorFormSchema';
 
+const mockUploadCoverImage = jest.fn();
+
+jest.mock('lib/trpc/client', () => ({
+  trpc: {
+    collect: {
+      uploadCoverImage: {
+        useMutation: () => ({
+          mutateAsync: mockUploadCoverImage,
+        }),
+      },
+    },
+  },
+}));
+
 jest.mock('next/image', () => ({
   __esModule: true,
   default: (props: Record<string, unknown>) => {
@@ -54,7 +68,7 @@ function CBBImagesTestHarness() {
 
   return (
     <FormProvider {...formMethods}>
-      <CBBImages blockID={0} />
+      <CBBImages blockID={0} spineColor="#ffffff" />
     </FormProvider>
   );
 }

--- a/__tests__/ui/cbbimages-upload.test.tsx
+++ b/__tests__/ui/cbbimages-upload.test.tsx
@@ -53,7 +53,14 @@ function CBBImagesUploadHarness({
       collectedData: [
         {
           type: mediaType,
-          images: [{ url: 'https://img/first.png', selected: false }],
+          images: [
+            {
+              url: 'https://img/first.png',
+              selected: true,
+              isDefault: true,
+              spineColor: '#ffffff',
+            },
+          ],
           blockInfo: {
             title: 'Dune',
             author: 'Frank Herbert',
@@ -94,6 +101,9 @@ describe('CBBImages upload slot', () => {
   test('appends uploaded image, selects it, and hides placeholder', async () => {
     mockUploadCoverImage.mockResolvedValueOnce({
       url: 'https://cdn.example.com/custom-cover.png',
+      selected: true,
+      isDefault: false,
+      spineColor: '#ffffff',
     });
 
     render(<CBBImagesUploadHarness mediaType="book" />);

--- a/__tests__/ui/cbbimages-upload.test.tsx
+++ b/__tests__/ui/cbbimages-upload.test.tsx
@@ -1,0 +1,122 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import CBBImages from '@/mediacollector/CBBImages';
+import type { CollectorFormData } from '@/mediacollector/collector-form/collectorFormSchema';
+
+const mockUploadCoverImage = jest.fn();
+
+jest.mock('lib/trpc/client', () => ({
+  trpc: {
+    collect: {
+      uploadCoverImage: {
+        useMutation: () => ({
+          mutateAsync: mockUploadCoverImage,
+        }),
+      },
+    },
+  },
+}));
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { alt, onError, fill, unoptimized, loader, ...rest } = props;
+    void fill;
+    void unoptimized;
+    void loader;
+    const imageErrorHandler =
+      typeof onError === 'function'
+        ? (onError as React.ReactEventHandler<HTMLImageElement>)
+        : undefined;
+    return <img alt={String(alt ?? '')} onError={imageErrorHandler} {...rest} />;
+  },
+}));
+
+function CBBImagesUploadHarness({
+  mediaType = 'book',
+}: {
+  mediaType?: 'book' | 'movie' | 'videoGame' | 'album';
+}) {
+  const formMethods = useForm<CollectorFormData>({
+    defaultValues: {
+      orderNumber: '123',
+      customerName: 'Test Customer',
+      bookClubRepeat: 0,
+      collectionList: {
+        book: [],
+        movie: [],
+        videoGame: [],
+        album: [],
+      },
+      collectedData: [
+        {
+          type: mediaType,
+          images: [{ url: 'https://img/first.png', selected: false }],
+          blockInfo: {
+            title: 'Dune',
+            author: 'Frank Herbert',
+            pubYear: 1965,
+            pageCount: 412,
+            spineColor: '#ffffff',
+            genres: [],
+          },
+          blockID: 'BLK-1',
+          isDatabase: false,
+        },
+      ],
+      pngFormat: '3',
+    },
+  });
+
+  return (
+    <FormProvider {...formMethods}>
+      <CBBImages blockID={0} spineColor="#ffffff" />
+    </FormProvider>
+  );
+}
+
+describe('CBBImages upload slot', () => {
+  beforeEach(() => {
+    mockUploadCoverImage.mockReset();
+  });
+
+  test('shows upload placeholder for non-database book blocks only', () => {
+    const { unmount } = render(<CBBImagesUploadHarness mediaType="book" />);
+    expect(screen.getByLabelText('Add uploaded book image')).toBeTruthy();
+
+    unmount();
+    render(<CBBImagesUploadHarness mediaType="movie" />);
+    expect(screen.queryByLabelText('Add uploaded book image')).toBeNull();
+  });
+
+  test('appends uploaded image, selects it, and hides placeholder', async () => {
+    mockUploadCoverImage.mockResolvedValueOnce({
+      url: 'https://cdn.example.com/custom-cover.png',
+    });
+
+    render(<CBBImagesUploadHarness mediaType="book" />);
+    const input = screen.getByLabelText('Upload book image');
+    const file = new File(['image-bytes'], 'cover.png', { type: 'image/png' });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(mockUploadCoverImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blockID: 'BLK-1',
+          fileName: 'cover.png',
+          mimeType: 'image/png',
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Add uploaded book image')).toBeNull();
+    });
+    await waitFor(() => {
+      expect(screen.getAllByAltText('book image')).toHaveLength(2);
+    });
+    expect(screen.getAllByText('Selected').length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/ui/edit-database-block-images.test.tsx
+++ b/__tests__/ui/edit-database-block-images.test.tsx
@@ -86,7 +86,14 @@ describe('EditDatabaseBlock image uploads', () => {
         <EditDatabaseBlock
           info={{
             type: 'book',
-            images: ['https://img/book-1.png'],
+            images: [
+              {
+                url: 'https://img/book-1.png',
+                isDefault: true,
+                selected: true,
+                spineColor: '#ffffff',
+              },
+            ],
             blockInfo: {
               title: 'Dune',
               author: 'Frank Herbert',
@@ -105,9 +112,12 @@ describe('EditDatabaseBlock image uploads', () => {
     expect(screen.getByLabelText('Add uploaded database image')).toBeTruthy();
   });
 
-  test('appends uploaded image and submits updated imageUrls', async () => {
+  test('appends uploaded image and submits updated images', async () => {
     mockUploadCoverImage.mockResolvedValueOnce({
       url: 'https://cdn.example.com/book-uploaded.png',
+      selected: true,
+      isDefault: false,
+      spineColor: '#ffffff',
     });
     mockDatabaseEdit.mockResolvedValueOnce({ message: 'Saved' });
 
@@ -116,7 +126,14 @@ describe('EditDatabaseBlock image uploads', () => {
         <EditDatabaseBlock
           info={{
             type: 'book',
-            images: ['https://img/book-1.png'],
+            images: [
+              {
+                url: 'https://img/book-1.png',
+                isDefault: true,
+                selected: true,
+                spineColor: '#ffffff',
+              },
+            ],
             blockInfo: {
               title: 'Dune',
               author: 'Frank Herbert',
@@ -162,9 +179,13 @@ describe('EditDatabaseBlock image uploads', () => {
         expect.objectContaining({
           type: 'book',
           item: expect.objectContaining({
-            imageUrls: [
-              'https://img/book-1.png',
-              'https://cdn.example.com/book-uploaded.png',
+            images: [
+              expect.objectContaining({
+                url: 'https://img/book-1.png',
+              }),
+              expect.objectContaining({
+                url: 'https://cdn.example.com/book-uploaded.png',
+              }),
             ],
           }),
         }),

--- a/__tests__/ui/edit-database-block-images.test.tsx
+++ b/__tests__/ui/edit-database-block-images.test.tsx
@@ -1,0 +1,174 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import EditDatabaseBlock from '@/showdatabase/EditDatabaseBlock';
+import GenreContext from 'lib/context/GenreContext';
+
+const mockDatabaseEdit = jest.fn();
+const mockUploadCoverImage = jest.fn();
+const mockLinkGenres = jest.fn();
+const mockUnlinkGenres = jest.fn();
+const mockInvalidateGenres = jest.fn();
+const mockHandleGetMedia = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('lib/context/DatabasePageContext', () => ({
+  useDatabasePageContext: () => ({
+    handleGetMedia: mockHandleGetMedia,
+  }),
+}));
+
+jest.mock('lib/trpc/client', () => ({
+  trpc: {
+    database: {
+      edit: {
+        useMutation: () => ({
+          mutateAsync: mockDatabaseEdit,
+        }),
+      },
+    },
+    collect: {
+      uploadCoverImage: {
+        useMutation: () => ({
+          mutateAsync: mockUploadCoverImage,
+        }),
+      },
+    },
+    genres: {
+      link: {
+        useMutation: () => ({
+          mutateAsync: mockLinkGenres,
+        }),
+      },
+      unlink: {
+        useMutation: () => ({
+          mutateAsync: mockUnlinkGenres,
+        }),
+      },
+    },
+    useUtils: () => ({
+      genres: {
+        getForBook: {
+          invalidate: mockInvalidateGenres,
+        },
+      },
+    }),
+  },
+}));
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { alt, onError, fill, unoptimized, loader, ...rest } = props;
+    void fill;
+    void unoptimized;
+    void loader;
+    const imageErrorHandler =
+      typeof onError === 'function'
+        ? (onError as React.ReactEventHandler<HTMLImageElement>)
+        : undefined;
+    return <img alt={String(alt ?? '')} onError={imageErrorHandler} {...rest} />;
+  },
+}));
+
+describe('EditDatabaseBlock image uploads', () => {
+  beforeEach(() => {
+    mockDatabaseEdit.mockReset();
+    mockUploadCoverImage.mockReset();
+    mockLinkGenres.mockReset();
+    mockUnlinkGenres.mockReset();
+    mockInvalidateGenres.mockReset();
+    mockHandleGetMedia.mockClear();
+  });
+
+  test('shows upload control for book edit block', () => {
+    render(
+      <GenreContext.Provider value={[]}>
+        <EditDatabaseBlock
+          info={{
+            type: 'book',
+            images: ['https://img/book-1.png'],
+            blockInfo: {
+              title: 'Dune',
+              author: 'Frank Herbert',
+              pubYear: 1965,
+              pageCount: 412,
+              spineColor: '#ffffff',
+              initialGenres: [],
+            },
+            id: 'book-id-1',
+            setEdit: jest.fn(),
+          }}
+        />
+      </GenreContext.Provider>,
+    );
+
+    expect(screen.getByLabelText('Add uploaded database image')).toBeTruthy();
+  });
+
+  test('appends uploaded image and submits updated imageUrls', async () => {
+    mockUploadCoverImage.mockResolvedValueOnce({
+      url: 'https://cdn.example.com/book-uploaded.png',
+    });
+    mockDatabaseEdit.mockResolvedValueOnce({ message: 'Saved' });
+
+    render(
+      <GenreContext.Provider value={[]}>
+        <EditDatabaseBlock
+          info={{
+            type: 'book',
+            images: ['https://img/book-1.png'],
+            blockInfo: {
+              title: 'Dune',
+              author: 'Frank Herbert',
+              pubYear: 1965,
+              pageCount: 412,
+              spineColor: '#ffffff',
+              initialGenres: [],
+            },
+            id: 'book-id-1',
+            setEdit: jest.fn(),
+          }}
+        />
+      </GenreContext.Provider>,
+    );
+
+    expect(screen.getAllByAltText('book image')).toHaveLength(1);
+
+    const input = screen.getByLabelText('Upload database image');
+    const file = new File(['image-bytes'], 'database-cover.png', {
+      type: 'image/png',
+    });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(mockUploadCoverImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blockID: 'book-id-1',
+          fileName: 'database-cover.png',
+          mimeType: 'image/png',
+          sortOrder: 1,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByAltText('book image')).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getByText('Submit Changes'));
+
+    await waitFor(() => {
+      expect(mockDatabaseEdit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'book',
+          item: expect.objectContaining({
+            imageUrls: [
+              'https://img/book-1.png',
+              'https://cdn.example.com/book-uploaded.png',
+            ],
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/__tests__/ui/media-image-strip.test.tsx
+++ b/__tests__/ui/media-image-strip.test.tsx
@@ -1,0 +1,63 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import MediaImageStrip from '@/shared/MediaImageStrip';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { alt, onError, fill, unoptimized, loader, ...rest } = props;
+    void fill;
+    void unoptimized;
+    void loader;
+    const imageErrorHandler =
+      typeof onError === 'function'
+        ? (onError as React.ReactEventHandler<HTMLImageElement>)
+        : undefined;
+    return <img alt={String(alt ?? '')} onError={imageErrorHandler} {...rest} />;
+  },
+}));
+
+describe('MediaImageStrip', () => {
+  test('renders default badge and overflow button for extra covers', () => {
+    render(
+      <MediaImageStrip
+        mediaType="book"
+        images={[
+          { url: 'https://img/1.png', isDefault: true, selected: true, spineColor: '#111111' },
+          { url: 'https://img/2.png', isDefault: false, selected: false, spineColor: '#222222' },
+          { url: 'https://img/3.png', isDefault: false, selected: false, spineColor: '#333333' },
+          { url: 'https://img/4.png', isDefault: false, selected: false, spineColor: '#444444' },
+          { url: 'https://img/5.png', isDefault: false, selected: false, spineColor: '#555555' },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByTestId('StarsIcon').length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: '+1' })).toBeTruthy();
+  });
+
+  test('uses selected image as primary and maps overflow click index', () => {
+    const onImageClick = jest.fn();
+    render(
+      <MediaImageStrip
+        mediaType="book"
+        onImageClick={onImageClick}
+        images={[
+          { url: 'https://img/1.png', isDefault: true, selected: false, spineColor: '#111111' },
+          { url: 'https://img/2.png', isDefault: false, selected: true, spineColor: '#222222' },
+          { url: 'https://img/3.png', isDefault: false, selected: false, spineColor: '#333333' },
+          { url: 'https://img/4.png', isDefault: false, selected: false, spineColor: '#444444' },
+          { url: 'https://img/5.png', isDefault: false, selected: false, spineColor: '#555555' },
+          { url: 'https://img/6.png', isDefault: false, selected: false, spineColor: '#666666' },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '+2' }));
+    const popoverImages = screen.getAllByAltText('book image');
+    fireEvent.click(popoverImages[popoverImages.length - 1]);
+
+    expect(onImageClick).toHaveBeenCalledWith(5);
+  });
+});

--- a/app/db/migrations/0007_media_image_item_default_spine.sql
+++ b/app/db/migrations/0007_media_image_item_default_spine.sql
@@ -1,0 +1,57 @@
+ALTER TABLE "media_image_items" ADD COLUMN "is_default" boolean DEFAULT false NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "media_image_items" ADD COLUMN "spine_color" text DEFAULT '#ffffff' NOT NULL;
+--> statement-breakpoint
+UPDATE "media_image_items" AS mii
+SET "spine_color" = b."spine_color"
+FROM "books" AS b
+WHERE mii."book_id" = b."id";
+--> statement-breakpoint
+UPDATE "media_image_items" AS mii
+SET "spine_color" = om."spine_color"
+FROM "other_media" AS om
+WHERE mii."other_media_id" = om."id";
+--> statement-breakpoint
+WITH ranked_book_images AS (
+  SELECT
+    "id",
+    row_number() OVER (
+      PARTITION BY "book_id"
+      ORDER BY "sort_order" ASC, "created_at" ASC, "id" ASC
+    ) AS image_rank
+  FROM "media_image_items"
+  WHERE "book_id" IS NOT NULL
+)
+UPDATE "media_image_items" AS mii
+SET "is_default" = (ranked_book_images."image_rank" = 1)
+FROM ranked_book_images
+WHERE ranked_book_images."id" = mii."id";
+--> statement-breakpoint
+WITH ranked_other_media_images AS (
+  SELECT
+    "id",
+    row_number() OVER (
+      PARTITION BY "other_media_id"
+      ORDER BY "sort_order" ASC, "created_at" ASC, "id" ASC
+    ) AS image_rank
+  FROM "media_image_items"
+  WHERE "other_media_id" IS NOT NULL
+)
+UPDATE "media_image_items" AS mii
+SET "is_default" = (ranked_other_media_images."image_rank" = 1)
+FROM ranked_other_media_images
+WHERE ranked_other_media_images."id" = mii."id";
+--> statement-breakpoint
+CREATE UNIQUE INDEX "media_image_items_book_default_unique"
+ON "media_image_items" USING btree ("book_id")
+WHERE "book_id" IS NOT NULL AND "is_default" = true;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "media_image_items_other_media_default_unique"
+ON "media_image_items" USING btree ("other_media_id")
+WHERE "other_media_id" IS NOT NULL AND "is_default" = true;
+--> statement-breakpoint
+CREATE INDEX "media_image_items_book_is_default_idx"
+ON "media_image_items" USING btree ("book_id", "is_default");
+--> statement-breakpoint
+CREATE INDEX "media_image_items_other_media_is_default_idx"
+ON "media_image_items" USING btree ("other_media_id", "is_default");

--- a/app/db/migrations/meta/_journal.json
+++ b/app/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1773576000000,
       "tag": "0006_drop_legacy_image_urls",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1773583200000,
+      "tag": "0007_media_image_item_default_spine",
+      "breakpoints": true
     }
   ]
 }

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -102,6 +102,8 @@ export const mediaImageItems = pgTable(
     mimeType: text('mime_type'),
     sizeBytes: integer('size_bytes'),
     sortOrder: integer('sort_order').notNull().default(0),
+    isDefault: boolean('is_default').notNull().default(false),
+    spineColor: text('spine_color').notNull().default('#ffffff'),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at')
       .defaultNow()
@@ -118,6 +120,11 @@ export const mediaImageItems = pgTable(
     index('media_image_items_other_media_sort_order_idx').on(
       table.otherMediaId,
       table.sortOrder,
+    ),
+    index('media_image_items_book_is_default_idx').on(table.bookId, table.isDefault),
+    index('media_image_items_other_media_is_default_idx').on(
+      table.otherMediaId,
+      table.isDefault,
     ),
   ],
 );

--- a/app/mediacollector/CBBImages.tsx
+++ b/app/mediacollector/CBBImages.tsx
@@ -1,11 +1,10 @@
 // interfaces and types
-import Image from 'next/image';
 import { CollectorFormData } from './collector-form/collectorFormSchema';
 import { ChangeEvent, useRef, useState } from 'react';
-import AddToPhotosIcon from '@mui/icons-material/AddToPhotos';
 
 import { useFormContext } from 'react-hook-form';
 import { trpc } from 'lib/trpc/client';
+import MediaImageStrip from '@/shared/MediaImageStrip';
 
 export interface CBBImageProps {
   blockID: number;
@@ -22,9 +21,6 @@ export default function CBBImages({ blockID, spineColor }: CBBImageProps) {
   const { watch, setValue } = useFormContext<CollectorFormData>();
   const { mutateAsync: uploadCoverImage } =
     trpc.collect.uploadCoverImage.useMutation();
-  const [brokenImageUrls, setBrokenImageUrls] = useState<
-    Record<string, boolean>
-  >({});
   const collectedData = watch('collectedData');
   const block = collectedData[blockID];
   if (!block) {
@@ -138,80 +134,29 @@ export default function CBBImages({ blockID, spineColor }: CBBImageProps) {
           onClick={() => handleColorPick(blockID)}
         ></div>
       ) : null}
-      {images.map((image, idx) => (
-        <div
-          className={`relative z-10 overflow-hidden rounded-sm ${
-            type === 'album' ? 'h-31 w-31' : 'h-31 w-21'
-          }`}
-          key={image.url}
-          onClick={() => {
-            if (!isDatabase) {
-              handleClick(image, idx);
-            }
-          }}
-        >
-          {brokenImageUrls[image.url] ? (
-            <div className="absolute inset-0 flex items-center justify-center rounded-sm bg-red-600/65 p-2 text-center text-sm font-bold text-white">
-              Image path broken
-            </div>
-          ) : (
-            <Image
-              className={
-                type === 'album'
-                  ? 'cursor-pointer object-cover outline-2'
-                  : 'cursor-pointer'
-              }
-              src={image.url}
-              alt={`${type} image`}
-              fill
-              sizes="(max-width: 640px) 33vw, (max-width: 1024px) 20vw, 200px"
-              unoptimized
-              loader={({ src }) => src}
-              onError={() =>
-                setBrokenImageUrls((previous) => ({
-                  ...previous,
-                  [image.url]: true,
-                }))
-              }
-            />
-          )}
-
-          <div
-            className={`pointer-events-none absolute inset-0 flex content-center items-center ${
-              image.selected ? 'opacity-100' : 'opacity-0'
-            }`}
-          >
-            <p className='-translate-x-1 -rotate-65 font-["Just_Another_Hand"] text-5xl font-bold tracking-wider text-[rgb(0,77,0)]'>
-              Selected
-            </p>
-          </div>
-        </div>
-      ))}
-      {showUploadSlot ? (
-        <>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
-            className="hidden"
-            onChange={handleUploadImage}
-            aria-label="Upload book image"
-          />
-          <button
-            type="button"
-            className="flex h-31 w-21 cursor-pointer items-center justify-center rounded-sm border-2 border-dashed border-black/60 bg-white/45 transition-opacity hover:opacity-85 disabled:cursor-not-allowed disabled:opacity-50"
-            onClick={() => fileInputRef.current?.click()}
-            disabled={isUploading}
-            aria-label="Add uploaded book image"
-          >
-            {isUploading ? (
-              <span className="text-center text-sm font-bold">Uploading...</span>
-            ) : (
-              <AddToPhotosIcon sx={{ fontSize: '2.25rem' }} />
-            )}
-          </button>
-        </>
-      ) : null}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleUploadImage}
+        aria-label="Upload book image"
+      />
+      <MediaImageStrip
+        mediaType={type}
+        images={images}
+        showSelectionOverlay
+        onImageClick={(imageIndex) => {
+          if (!isDatabase) {
+            handleClick(images[imageIndex], imageIndex);
+          }
+        }}
+        showUploadButton={showUploadSlot}
+        isUploading={isUploading}
+        onUploadButtonClick={() => fileInputRef.current?.click()}
+        uploadButtonLabel="Add uploaded book image"
+        uploadSlotLabel="Uploading..."
+      />
     </div>
   );
 }

--- a/app/mediacollector/CBBImages.tsx
+++ b/app/mediacollector/CBBImages.tsx
@@ -1,19 +1,30 @@
 // interfaces and types
 import Image from 'next/image';
 import { CollectorFormData } from './collector-form/collectorFormSchema';
-import { useState } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
+import AddToPhotosIcon from '@mui/icons-material/AddToPhotos';
 
 import { useFormContext } from 'react-hook-form';
+import { trpc } from 'lib/trpc/client';
 
 export interface CBBImageProps {
   blockID: number;
+  spineColor: string;
 }
 
-export default function CBBImages({ blockID }: CBBImageProps) {
+export default function CBBImages({ blockID, spineColor }: CBBImageProps) {
+  //set local state for spine color
+  const [color, setColor] = useState(spineColor);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [hasUploadedCustomImage, setHasUploadedCustomImage] = useState(false);
+
   const { watch, setValue } = useFormContext<CollectorFormData>();
-  const [brokenImageUrls, setBrokenImageUrls] = useState<Record<string, boolean>>(
-    {},
-  );
+  const { mutateAsync: uploadCoverImage } =
+    trpc.collect.uploadCoverImage.useMutation();
+  const [brokenImageUrls, setBrokenImageUrls] = useState<
+    Record<string, boolean>
+  >({});
   const collectedData = watch('collectedData');
   const block = collectedData[blockID];
   if (!block) {
@@ -52,8 +63,81 @@ export default function CBBImages({ blockID }: CBBImageProps) {
     }
   };
 
+  const handleColorPick = async (blockID: number) => {
+    if (!window.EyeDropper) {
+      console.log('EyeDropper API not supported in this browser');
+      return;
+    }
+    const eyeDropper = new window.EyeDropper();
+    try {
+      const { sRGBHex } = await eyeDropper.open();
+      const spineColor = sRGBHex;
+      setColor(spineColor);
+      setValue(`collectedData.${blockID}.blockInfo.spineColor`, spineColor);
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  const convertFileToBase64 = (file: File): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result;
+        if (typeof result !== 'string') {
+          reject(new Error('Unable to read uploaded file.'));
+          return;
+        }
+        const [, dataBase64 = ''] = result.split(',');
+        resolve(dataBase64);
+      };
+      reader.onerror = () => {
+        reject(new Error('Unable to read uploaded file.'));
+      };
+      reader.readAsDataURL(file);
+    });
+
+  const handleUploadImage = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    setIsUploading(true);
+    try {
+      const dataBase64 = await convertFileToBase64(file);
+      const { url } = await uploadCoverImage({
+        blockID: block.blockID,
+        sortOrder: images.length,
+        fileName: file.name,
+        mimeType: file.type,
+        dataBase64,
+      });
+
+      setValue(`collectedData.${blockID}`, {
+        ...block,
+        images: [...images, { url, selected: true }],
+      });
+      setHasUploadedCustomImage(true);
+    } catch (error) {
+      console.error('Failed to upload custom book image', error);
+    } finally {
+      setIsUploading(false);
+      event.target.value = '';
+    }
+  };
+
+  const showUploadSlot = type === 'book' && !isDatabase && !hasUploadedCustomImage;
+
   return (
-    <div className="mx-10 mt-2.5 flex flex-row items-center gap-5">
+    <div className="mx-10 mt-2.5 flex flex-row items-center gap-3">
+      {type !== 'album' ? (
+        <div
+          className="h-full w-5 cursor-pointer rounded-sm"
+          style={{ backgroundColor: color }}
+          onClick={() => handleColorPick(blockID)}
+        ></div>
+      ) : null}
       {images.map((image, idx) => (
         <div
           className={`relative z-10 overflow-hidden rounded-sm ${
@@ -103,6 +187,31 @@ export default function CBBImages({ blockID }: CBBImageProps) {
           </div>
         </div>
       ))}
+      {showUploadSlot ? (
+        <>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleUploadImage}
+            aria-label="Upload book image"
+          />
+          <button
+            type="button"
+            className="flex h-31 w-21 cursor-pointer items-center justify-center rounded-sm border-2 border-dashed border-black/60 bg-white/45 transition-opacity hover:opacity-85 disabled:cursor-not-allowed disabled:opacity-50"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={isUploading}
+            aria-label="Add uploaded book image"
+          >
+            {isUploading ? (
+              <span className="text-center text-sm font-bold">Uploading...</span>
+            ) : (
+              <AddToPhotosIcon sx={{ fontSize: '2.25rem' }} />
+            )}
+          </button>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/app/mediacollector/CBBImages.tsx
+++ b/app/mediacollector/CBBImages.tsx
@@ -29,34 +29,24 @@ export default function CBBImages({ blockID, spineColor }: CBBImageProps) {
   const { type, images, isDatabase } = block;
   //setup connection to redux slice
 
-  //add the image url to the database data (in the state) or removes it if its there already
-  const handleClick = (
-    image: { url: string; selected: boolean },
-    imageIdx: number,
-  ) => {
-    if (!image.selected) {
-      const newBlockImages = block.images.map((img, idx) => {
-        if (idx === imageIdx) {
-          return { ...img, selected: true };
-        }
-        return img;
-      });
-      setValue(`collectedData.${blockID}`, {
-        ...block,
-        images: newBlockImages,
-      });
-    } else {
-      const newBlockImages = block.images.map((img, idx) => {
-        if (idx === imageIdx) {
-          return { ...img, selected: false };
-        }
-        return img;
-      });
-      setValue(`collectedData.${blockID}`, {
-        ...block,
-        images: newBlockImages,
-      });
+  const handleImageSelection = (imageIdx: number) => {
+    const selectedImage = block.images[imageIdx];
+    if (!selectedImage) {
+      return;
     }
+    const nextImages = block.images.map((image, index) => ({
+      ...image,
+      selected: index === imageIdx,
+    }));
+    setColor(selectedImage.spineColor);
+    setValue(`collectedData.${blockID}`, {
+      ...block,
+      images: nextImages,
+      blockInfo: {
+        ...block.blockInfo,
+        spineColor: selectedImage.spineColor,
+      },
+    });
   };
 
   const handleColorPick = async (blockID: number) => {
@@ -69,7 +59,19 @@ export default function CBBImages({ blockID, spineColor }: CBBImageProps) {
       const { sRGBHex } = await eyeDropper.open();
       const spineColor = sRGBHex;
       setColor(spineColor);
-      setValue(`collectedData.${blockID}.blockInfo.spineColor`, spineColor);
+      const selectedImageIndex = block.images.findIndex((image) => image.selected);
+      const imageIndexToUpdate = selectedImageIndex >= 0 ? selectedImageIndex : 0;
+      const nextImages = block.images.map((image, index) =>
+        index === imageIndexToUpdate ? { ...image, spineColor } : image,
+      );
+      setValue(`collectedData.${blockID}`, {
+        ...block,
+        images: nextImages,
+        blockInfo: {
+          ...block.blockInfo,
+          spineColor,
+        },
+      });
     } catch (e) {
       console.log(e);
     }
@@ -102,7 +104,7 @@ export default function CBBImages({ blockID, spineColor }: CBBImageProps) {
     setIsUploading(true);
     try {
       const dataBase64 = await convertFileToBase64(file);
-      const { url } = await uploadCoverImage({
+      const uploadedImage = await uploadCoverImage({
         blockID: block.blockID,
         sortOrder: images.length,
         fileName: file.name,
@@ -112,7 +114,19 @@ export default function CBBImages({ blockID, spineColor }: CBBImageProps) {
 
       setValue(`collectedData.${blockID}`, {
         ...block,
-        images: [...images, { url, selected: true }],
+        images: [
+          ...images.map((image) => ({ ...image, selected: false })),
+          {
+            url: uploadedImage.url,
+            selected: true,
+            isDefault: images.length === 0,
+            spineColor: color,
+          },
+        ],
+        blockInfo: {
+          ...block.blockInfo,
+          spineColor: color,
+        },
       });
       setHasUploadedCustomImage(true);
     } catch (error) {
@@ -147,9 +161,7 @@ export default function CBBImages({ blockID, spineColor }: CBBImageProps) {
         images={images}
         showSelectionOverlay
         onImageClick={(imageIndex) => {
-          if (!isDatabase) {
-            handleClick(images[imageIndex], imageIndex);
-          }
+          handleImageSelection(imageIndex);
         }}
         showUploadButton={showUploadSlot}
         isUploading={isUploading}

--- a/app/mediacollector/CollectedCoversBlock.tsx
+++ b/app/mediacollector/CollectedCoversBlock.tsx
@@ -1,5 +1,5 @@
 // react
-import { memo, useContext, useState } from 'react';
+import { memo, useContext } from 'react';
 
 //import icons and items from Material UI
 import BookIcon from '@mui/icons-material/BookTwoTone';
@@ -40,11 +40,11 @@ declare global {
 
 //styling of the block itself based on type
 export const blockClasses = {
-  book: 'bg-darkpink border-[#805052]',
-  movie: 'bg-[#323b43] border-black text-white',
-  album: 'bg-[#7fa5a3] border-[#354544]',
-  videoGame: 'bg-[#98ab88] border-[#4e8885]',
-  hasError: 'bg-[#E86C54] border-[#EB4423]',
+  book: 'bg-[#e1b3b5]',
+  movie: 'bg-[#323b43] text-white',
+  album: 'bg-[#7fa5a3]',
+  videoGame: 'bg-[#98ab88]',
+  hasError: 'bg-[#E86C54]',
 };
 
 const CollectedCoversBlock = memo(function CollectedCoversBlock({
@@ -55,13 +55,10 @@ const CollectedCoversBlock = memo(function CollectedCoversBlock({
 }: CollectedCoversBlockProps) {
   const {
     type,
-    blockInfo: { title, spineColor = '#ffffff', genres = [] },
+    blockInfo: { title, genres = [] },
     blockID,
     isDatabase,
   } = info;
-
-  //set local state for spine color
-  const [color, setColor] = useState(spineColor);
 
   //get genres for checkbox population
   const allGenres = useContext(GenreContext);
@@ -85,25 +82,6 @@ const CollectedCoversBlock = memo(function CollectedCoversBlock({
 
   //div to pick a color for the spine.
   //this is used in png creation and is required for each media type in the database
-  const handleColorPick = async (blockID: number) => {
-    if (!window.EyeDropper) {
-      console.log('EyeDropper API not supported in this browser');
-      return;
-    }
-    const eyeDropper = new window.EyeDropper();
-    try {
-      const { sRGBHex } = await eyeDropper.open();
-      const spineColor = sRGBHex;
-      setColor(spineColor);
-      const newBlock = {
-        ...info,
-        blockInfo: { ...info.blockInfo, spineColor },
-      };
-      setValue(`collectedData.${blockID}`, newBlock);
-    } catch (e) {
-      console.log(e);
-    }
-  };
 
   //if genre is clicked we add it to the data associated with the block and remove if unchecked
   const handleGenreClick = (genreText: string, checked: boolean) => {
@@ -120,14 +98,13 @@ const CollectedCoversBlock = memo(function CollectedCoversBlock({
         ...info,
         blockInfo: { ...info.blockInfo, genres: newGenres },
       };
-      console.log('newBlock in genre select', newBlock);
       setValue(`collectedData.${index}`, newBlock);
     }
   };
 
   return (
     <div
-      className={`relative flex h-fit w-lg flex-col items-center gap-2.5 rounded-lg border-2 shadow-[5px_5px_30px_rgba(0,0,0,0.3)] ${hasError ? blockClasses.hasError : blockClasses[type]}`}
+      className={`relative flex h-full w-full flex-col items-center gap-1.5 rounded-lg shadow-[5px_5px_30px_rgba(0,0,0,0.3)] ${hasError ? blockClasses.hasError : blockClasses[type]}`}
     >
       {isDatabase && (
         <p className="absolute top-9 left-1 m-0 rounded-sm border-2 border-black bg-gray-700 p-1.25 tracking-wider text-white">
@@ -144,22 +121,14 @@ const CollectedCoversBlock = memo(function CollectedCoversBlock({
           bottom: '4px',
           right: '4px',
           padding: '0',
-          // color: type === 'movie' ? 'white' : '',
+          color: type === 'movie' ? 'white' : '',
         }}
         onClick={() => handleDeleteBlock(blockID)}
       >
         <DeleteIcon />
       </IconButton>
-      <CBBImages blockID={index} />
-      {/* {type !== 'album' ? ( */}
-      <div
-        className="h-5 w-1/2 cursor-pointer"
-        style={{ backgroundColor: color }}
-        onClick={() => handleColorPick(index)}
-      ></div>
-      {/* ) : (
-        <></>
-      )} */}
+
+      <CBBImages blockID={index} spineColor={info.blockInfo.spineColor} />
 
       <MyTextArea
         name="title"

--- a/app/mediacollector/CollectedCoversBlock.tsx
+++ b/app/mediacollector/CollectedCoversBlock.tsx
@@ -2,10 +2,6 @@
 import { memo, useContext } from 'react';
 
 //import icons and items from Material UI
-import BookIcon from '@mui/icons-material/BookTwoTone';
-import MovieIcon from '@mui/icons-material/LocalMoviesTwoTone';
-import VideoGameIcon from '@mui/icons-material/VideogameAssetTwoTone';
-import AlbumIcon from '@mui/icons-material/AlbumTwoTone';
 import IconButton from '@mui/material/IconButton';
 import DeleteIcon from '@mui/icons-material/Delete';
 
@@ -20,6 +16,7 @@ import {
   CollectedBlockInformation,
   CollectorFormData,
 } from './collector-form/collectorFormSchema';
+import { blockClasses, icons } from 'lib/constants/typeBlockStyles';
 
 export interface CollectedCoversBlockProps {
   index: number;
@@ -39,13 +36,6 @@ declare global {
 }
 
 //styling of the block itself based on type
-export const blockClasses = {
-  book: 'bg-[#e1b3b5]',
-  movie: 'bg-[#323b43] text-white',
-  album: 'bg-[#7fa5a3]',
-  videoGame: 'bg-[#98ab88]',
-  hasError: 'bg-[#E86C54]',
-};
 
 const CollectedCoversBlock = memo(function CollectedCoversBlock({
   hasError,
@@ -73,12 +63,6 @@ const CollectedCoversBlock = memo(function CollectedCoversBlock({
   //setup connection to redux slice
 
   //establish variables for icons
-  const icons = {
-    book: <BookIcon />,
-    movie: <MovieIcon />,
-    videoGame: <VideoGameIcon />,
-    album: <AlbumIcon />,
-  };
 
   //div to pick a color for the spine.
   //this is used in png creation and is required for each media type in the database

--- a/app/mediacollector/TitleBlockContainer.tsx
+++ b/app/mediacollector/TitleBlockContainer.tsx
@@ -18,15 +18,19 @@ const TitleBlockContainer = memo(function TitleBlockContainer({
   const blocks = watch('collectedData') ?? [];
 
   return (
-    <div className="flex w-full flex-row flex-wrap gap-3 p-2">
+    <div className="grid w-full grid-cols-1 gap-3 p-2 sm:grid-flow-dense sm:grid-cols-[repeat(auto-fill,minmax(30rem,1fr))] sm:auto-rows-[15rem]">
       {blocks.map((block, idx) => (
-        <CollectedCoversBlock
-          index={idx}
-          info={block}
+        <div
           key={block.blockID}
-          handleDeleteBlock={handleDeleteBlock}
-          hasError={blockIdsWithErrors.includes(block.blockID)}
-        />
+          className={block.type === 'book' ? 'sm:row-span-2' : 'sm:row-span-1'}
+        >
+          <CollectedCoversBlock
+            index={idx}
+            info={block}
+            handleDeleteBlock={handleDeleteBlock}
+            hasError={blockIdsWithErrors.includes(block.blockID)}
+          />
+        </div>
       ))}
     </div>
   );

--- a/app/mediacollector/collector-form/collectorFormSchema.ts
+++ b/app/mediacollector/collector-form/collectorFormSchema.ts
@@ -17,6 +17,8 @@ export const otherMediaBlockInfoSchema = baseBlockInfoSchema;
 const imageSelectionSchema = z.object({
   url: z.string(),
   selected: z.boolean(),
+  isDefault: z.boolean(),
+  spineColor: z.string(),
 });
 
 export const collectedBlockInformationSchema = z.object({
@@ -29,6 +31,15 @@ export const collectedBlockInformationSchema = z.object({
   }),
   blockID: z.string(),
   isDatabase: z.boolean(),
+}).superRefine((value, ctx) => {
+  const selectedCount = value.images.filter((image) => image.selected).length;
+  if (selectedCount > 1) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Only one image can be selected at a time.',
+      path: ['images'],
+    });
+  }
 });
 
 export const collectorFormSchema = z.object({

--- a/app/mediacollector/page.tsx
+++ b/app/mediacollector/page.tsx
@@ -25,6 +25,7 @@ import Button from '@/components/ui/Button';
 import { useCollectorForm } from './collector-form/use-collector-form';
 import type { CollectorFormData } from './collector-form/collectorFormSchema';
 import { FormProvider, useFormContext } from 'react-hook-form';
+import { buildPNGExportImages } from './png-export-images';
 
 const backgroundImage = '/FlowerBackground.png';
 const mediaCollectorTitleImage = '/MegsMediaCollector.png';
@@ -140,23 +141,7 @@ function MediaCollectorContent() {
     }
 
     setLoadingMessage(`Putting together PNG export`);
-    const images = formValues.collectedData.map((block) => {
-      let keptImages: { url: string; selected: boolean }[] = [];
-      if (block.isDatabase) {
-        keptImages = block.images;
-      } else {
-        keptImages = block.images.filter((img) => img.selected);
-      }
-
-      const url = keptImages.map((img) => img.url)[0];
-      const type = block.type;
-      const spineColor = block.blockInfo.spineColor;
-      return {
-        url,
-        type,
-        spineColor,
-      };
-    });
+    const images = buildPNGExportImages(formValues.collectedData);
 
     const { mime, filename, dataBase64 } = await createPNG({
       template: Number(formValues.pngFormat) as 3 | 5,

--- a/app/mediacollector/png-export-images.ts
+++ b/app/mediacollector/png-export-images.ts
@@ -1,0 +1,38 @@
+import type { CollectorFormData } from './collector-form/collectorFormSchema';
+
+type CollectedBlock = CollectorFormData['collectedData'][number];
+
+export type PNGExportImage = {
+  url: string;
+  type: CollectedBlock['type'];
+  spineColor: string;
+};
+
+function getImageForPNG(block: CollectedBlock) {
+  const selectedImage = block.images.find((image) => image.selected);
+  if (selectedImage) {
+    return selectedImage;
+  }
+
+  const defaultImage = block.images.find((image) => image.isDefault);
+  return defaultImage ?? block.images[0];
+}
+
+export function buildPNGExportImages(
+  collectedData: CollectorFormData['collectedData'],
+): PNGExportImage[] {
+  return collectedData.flatMap((block) => {
+    const image = getImageForPNG(block);
+    if (!image) {
+      return [];
+    }
+
+    return [
+      {
+        url: image.url,
+        type: block.type,
+        spineColor: image.spineColor,
+      },
+    ];
+  });
+}

--- a/app/shared/MediaImageStrip.tsx
+++ b/app/shared/MediaImageStrip.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import Image from 'next/image';
+import AddToPhotosIcon from '@mui/icons-material/AddToPhotos';
+import { MediaType } from 'lib/constants/mediaTypes';
+
+export interface MediaImageStripItem {
+  url: string;
+  selected?: boolean;
+}
+
+export interface MediaImageStripProps {
+  mediaType: MediaType;
+  images: MediaImageStripItem[];
+  className?: string;
+  albumTileClassName?: string;
+  defaultTileClassName?: string;
+  albumImageClassName?: string;
+  defaultImageClassName?: string;
+  showSelectionOverlay?: boolean;
+  selectionOverlayText?: string;
+  onImageClick?: (imageIndex: number) => void;
+  showUploadButton?: boolean;
+  isUploading?: boolean;
+  onUploadButtonClick?: () => void;
+  uploadButtonLabel?: string;
+  uploadSlotLabel?: string;
+}
+
+const DEFAULT_ALBUM_TILE_CLASS =
+  'relative z-10 h-31 w-31 overflow-hidden rounded-sm';
+const DEFAULT_TILE_CLASS = 'relative z-10 h-31 w-21 overflow-hidden rounded-sm';
+const DEFAULT_ALBUM_IMAGE_CLASS = 'cursor-pointer object-cover outline-2';
+const DEFAULT_IMAGE_CLASS = 'cursor-pointer';
+
+export default function MediaImageStrip({
+  mediaType,
+  images,
+  className = 'flex flex-row items-center gap-3',
+  albumTileClassName = DEFAULT_ALBUM_TILE_CLASS,
+  defaultTileClassName = DEFAULT_TILE_CLASS,
+  albumImageClassName = DEFAULT_ALBUM_IMAGE_CLASS,
+  defaultImageClassName = DEFAULT_IMAGE_CLASS,
+  showSelectionOverlay = false,
+  selectionOverlayText = 'Selected',
+  onImageClick,
+  showUploadButton = false,
+  isUploading = false,
+  onUploadButtonClick,
+  uploadButtonLabel = 'Add uploaded image',
+  uploadSlotLabel = 'Uploading...',
+}: MediaImageStripProps) {
+  const [brokenImageUrls, setBrokenImageUrls] = useState<Record<string, boolean>>({});
+
+  const tileClassName =
+    mediaType === 'album' ? albumTileClassName : defaultTileClassName;
+  const imageClassName =
+    mediaType === 'album' ? albumImageClassName : defaultImageClassName;
+
+  return (
+    <div className={className}>
+      {images.map((image, idx) => (
+        <div
+          className={tileClassName}
+          key={`${image.url}-${idx}`}
+          onClick={() => onImageClick?.(idx)}
+        >
+          {brokenImageUrls[image.url] ? (
+            <div className="absolute inset-0 flex items-center justify-center rounded-sm bg-red-600/65 p-2 text-center text-sm font-bold text-white">
+              Image path broken
+            </div>
+          ) : (
+            <Image
+              className={imageClassName}
+              src={image.url}
+              alt={`${mediaType} image`}
+              fill
+              sizes="(max-width: 640px) 33vw, (max-width: 1024px) 20vw, 200px"
+              unoptimized
+              loader={({ src }) => src}
+              onError={() =>
+                setBrokenImageUrls((previous) => ({
+                  ...previous,
+                  [image.url]: true,
+                }))
+              }
+            />
+          )}
+
+          {showSelectionOverlay ? (
+            <div
+              className={`pointer-events-none absolute inset-0 flex content-center items-center ${
+                image.selected ? 'opacity-100' : 'opacity-0'
+              }`}
+            >
+              <p className='-translate-x-1 -rotate-65 font-["Just_Another_Hand"] text-5xl font-bold tracking-wider text-[rgb(0,77,0)]'>
+                {selectionOverlayText}
+              </p>
+            </div>
+          ) : null}
+        </div>
+      ))}
+
+      {showUploadButton ? (
+        <button
+          type="button"
+          className="flex h-31 w-21 cursor-pointer items-center justify-center rounded-sm border-2 border-dashed border-black/60 bg-white/45 transition-opacity hover:opacity-85 disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={onUploadButtonClick}
+          disabled={isUploading}
+          aria-label={uploadButtonLabel}
+        >
+          {isUploading ? (
+            <span className="text-center text-sm font-bold">{uploadSlotLabel}</span>
+          ) : (
+            <AddToPhotosIcon sx={{ fontSize: '2.25rem' }} />
+          )}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/app/shared/MediaImageStrip.tsx
+++ b/app/shared/MediaImageStrip.tsx
@@ -53,7 +53,9 @@ export default function MediaImageStrip({
   uploadButtonLabel = 'Add uploaded image',
   uploadSlotLabel = 'Uploading...',
 }: MediaImageStripProps) {
-  const [brokenImageUrls, setBrokenImageUrls] = useState<Record<string, boolean>>({});
+  const [brokenImageUrls, setBrokenImageUrls] = useState<
+    Record<string, boolean>
+  >({});
   const [overflowAnchorElement, setOverflowAnchorElement] =
     useState<HTMLButtonElement | null>(null);
 
@@ -66,7 +68,8 @@ export default function MediaImageStrip({
     0,
   );
   const selectedImageIndex = images.findIndex((image) => image.selected);
-  const primaryImageIndex = selectedImageIndex >= 0 ? selectedImageIndex : defaultImageIndex;
+  const primaryImageIndex =
+    selectedImageIndex >= 0 ? selectedImageIndex : defaultImageIndex;
   const primaryImage = images[primaryImageIndex];
   const secondaryImages = images
     .map((image, index) => ({ image, originalIndex: index }))
@@ -118,12 +121,6 @@ export default function MediaImageStrip({
         />
       )}
 
-      {image.isDefault ? (
-        <div className="pointer-events-none absolute -top-2 -left-2 z-20 overflow-visible rounded-full bg-yellow-400 p-1 text-black shadow-md">
-          <StarsIcon sx={{ fontSize: '1.15rem' }} />
-        </div>
-      ) : null}
-
       {showSelectionOverlay ? (
         <div
           className={`pointer-events-none absolute inset-0 flex content-center items-center ${
@@ -148,7 +145,7 @@ export default function MediaImageStrip({
           )
         : null}
       {secondaryImages.length > 0 ? (
-        <div className="grid h-31 w-21 grid-cols-2 grid-rows-2 gap-1 overflow-visible rounded-sm border border-black/25 bg-black/5 p-1">
+        <div className="grid h-31 w-21 grid-cols-2 grid-rows-2 gap-1 overflow-visible">
           {secondaryVisibleImages.map(({ image, originalIndex }) => (
             <button
               type="button"
@@ -240,7 +237,9 @@ export default function MediaImageStrip({
           aria-label={uploadButtonLabel}
         >
           {isUploading ? (
-            <span className="text-center text-sm font-bold">{uploadSlotLabel}</span>
+            <span className="text-center text-sm font-bold">
+              {uploadSlotLabel}
+            </span>
           ) : (
             <AddToPhotosIcon sx={{ fontSize: '2.25rem' }} />
           )}

--- a/app/shared/MediaImageStrip.tsx
+++ b/app/shared/MediaImageStrip.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
 import Image from 'next/image';
 import AddToPhotosIcon from '@mui/icons-material/AddToPhotos';
+import StarsIcon from '@mui/icons-material/Stars';
+import Popover from '@mui/material/Popover';
 import { MediaType } from 'lib/constants/mediaTypes';
 
 export interface MediaImageStripItem {
   url: string;
   selected?: boolean;
+  isDefault?: boolean;
+  spineColor?: string;
 }
 
 export interface MediaImageStripProps {
@@ -50,55 +54,182 @@ export default function MediaImageStrip({
   uploadSlotLabel = 'Uploading...',
 }: MediaImageStripProps) {
   const [brokenImageUrls, setBrokenImageUrls] = useState<Record<string, boolean>>({});
+  const [overflowAnchorElement, setOverflowAnchorElement] =
+    useState<HTMLButtonElement | null>(null);
 
   const tileClassName =
     mediaType === 'album' ? albumTileClassName : defaultTileClassName;
   const imageClassName =
     mediaType === 'album' ? albumImageClassName : defaultImageClassName;
+  const defaultImageIndex = Math.max(
+    images.findIndex((image) => image.isDefault),
+    0,
+  );
+  const selectedImageIndex = images.findIndex((image) => image.selected);
+  const primaryImageIndex = selectedImageIndex >= 0 ? selectedImageIndex : defaultImageIndex;
+  const primaryImage = images[primaryImageIndex];
+  const secondaryImages = images
+    .map((image, index) => ({ image, originalIndex: index }))
+    .filter((record) => record.originalIndex !== primaryImageIndex);
+  const secondaryVisibleImages = secondaryImages.slice(0, 3);
+  const overflowImages = secondaryImages.slice(3);
+  const showOverflowButton = overflowImages.length > 0;
+
+  const tileImageClassName = `cursor-pointer ${imageClassName}`.trim();
+
+  const renderImageTile = (
+    image: MediaImageStripItem,
+    imageIndex: number,
+    key: string,
+    useGridImageClass = false,
+  ) => (
+    <div
+      className={tileClassName}
+      key={key}
+      onClick={() => onImageClick?.(imageIndex)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onImageClick?.(imageIndex);
+        }
+      }}
+    >
+      {brokenImageUrls[image.url] ? (
+        <div className="absolute inset-0 flex items-center justify-center rounded-sm bg-red-600/65 p-2 text-center text-sm font-bold text-white">
+          Image path broken
+        </div>
+      ) : (
+        <Image
+          className={useGridImageClass ? 'object-cover' : tileImageClassName}
+          src={image.url}
+          alt={`${mediaType} image`}
+          fill
+          sizes="(max-width: 640px) 33vw, (max-width: 1024px) 20vw, 200px"
+          unoptimized
+          loader={({ src }) => src}
+          onError={() =>
+            setBrokenImageUrls((previous) => ({
+              ...previous,
+              [image.url]: true,
+            }))
+          }
+        />
+      )}
+
+      {image.isDefault ? (
+        <div className="pointer-events-none absolute -top-2 -left-2 z-20 overflow-visible rounded-full bg-yellow-400 p-1 text-black shadow-md">
+          <StarsIcon sx={{ fontSize: '1.15rem' }} />
+        </div>
+      ) : null}
+
+      {showSelectionOverlay ? (
+        <div
+          className={`pointer-events-none absolute inset-0 flex content-center items-center ${
+            image.selected ? 'opacity-100' : 'opacity-0'
+          }`}
+        >
+          <p className='-translate-x-1 -rotate-65 font-["Just_Another_Hand"] text-5xl font-bold tracking-wider text-[rgb(0,77,0)]'>
+            {selectionOverlayText}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
 
   return (
     <div className={className}>
-      {images.map((image, idx) => (
-        <div
-          className={tileClassName}
-          key={`${image.url}-${idx}`}
-          onClick={() => onImageClick?.(idx)}
-        >
-          {brokenImageUrls[image.url] ? (
-            <div className="absolute inset-0 flex items-center justify-center rounded-sm bg-red-600/65 p-2 text-center text-sm font-bold text-white">
-              Image path broken
-            </div>
-          ) : (
-            <Image
-              className={imageClassName}
-              src={image.url}
-              alt={`${mediaType} image`}
-              fill
-              sizes="(max-width: 640px) 33vw, (max-width: 1024px) 20vw, 200px"
-              unoptimized
-              loader={({ src }) => src}
-              onError={() =>
-                setBrokenImageUrls((previous) => ({
-                  ...previous,
-                  [image.url]: true,
-                }))
-              }
-            />
-          )}
-
-          {showSelectionOverlay ? (
-            <div
-              className={`pointer-events-none absolute inset-0 flex content-center items-center ${
-                image.selected ? 'opacity-100' : 'opacity-0'
-              }`}
+      {primaryImage
+        ? renderImageTile(
+            primaryImage,
+            primaryImageIndex,
+            `${primaryImage.url}-${primaryImageIndex}`,
+          )
+        : null}
+      {secondaryImages.length > 0 ? (
+        <div className="grid h-31 w-21 grid-cols-2 grid-rows-2 gap-1 overflow-visible rounded-sm border border-black/25 bg-black/5 p-1">
+          {secondaryVisibleImages.map(({ image, originalIndex }) => (
+            <button
+              type="button"
+              className="relative overflow-visible rounded-sm"
+              key={`${image.url}-${originalIndex}`}
+              onClick={() => onImageClick?.(originalIndex)}
             >
-              <p className='-translate-x-1 -rotate-65 font-["Just_Another_Hand"] text-5xl font-bold tracking-wider text-[rgb(0,77,0)]'>
-                {selectionOverlayText}
-              </p>
-            </div>
+              {brokenImageUrls[image.url] ? (
+                <div className="absolute inset-0 flex items-center justify-center rounded-sm bg-red-600/65 p-1 text-center text-[10px] font-bold text-white">
+                  Broken
+                </div>
+              ) : (
+                <Image
+                  className="object-cover"
+                  src={image.url}
+                  alt={`${mediaType} image`}
+                  fill
+                  sizes="80px"
+                  unoptimized
+                  loader={({ src }) => src}
+                  onError={() =>
+                    setBrokenImageUrls((previous) => ({
+                      ...previous,
+                      [image.url]: true,
+                    }))
+                  }
+                />
+              )}
+              {image.isDefault ? (
+                <div className="pointer-events-none absolute -top-2 -left-2 z-20 rounded-full bg-yellow-400 p-0.5 text-black shadow-md">
+                  <StarsIcon sx={{ fontSize: '0.95rem' }} />
+                </div>
+              ) : null}
+            </button>
+          ))}
+          {showOverflowButton ? (
+            <button
+              type="button"
+              className="rounded-sm border border-black/40 bg-black/70 text-xs font-bold text-white"
+              onClick={(event) => setOverflowAnchorElement(event.currentTarget)}
+            >
+              +{overflowImages.length}
+            </button>
           ) : null}
         </div>
-      ))}
+      ) : null}
+      <Popover
+        open={Boolean(overflowAnchorElement)}
+        anchorEl={overflowAnchorElement}
+        onClose={() => setOverflowAnchorElement(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      >
+        <div className="grid max-w-sm grid-cols-2 gap-2 p-2">
+          {overflowImages.map(({ image, originalIndex }) => (
+            <button
+              type="button"
+              key={`${image.url}-${originalIndex}-popover`}
+              className="relative h-24 w-16 overflow-hidden rounded-sm"
+              onClick={() => {
+                onImageClick?.(originalIndex);
+                setOverflowAnchorElement(null);
+              }}
+            >
+              <Image
+                className="object-cover"
+                src={image.url}
+                alt={`${mediaType} image`}
+                fill
+                sizes="100px"
+                unoptimized
+                loader={({ src }) => src}
+              />
+              {image.isDefault ? (
+                <div className="pointer-events-none absolute top-1 left-1 rounded-full bg-yellow-400 p-0.5 text-black shadow-md">
+                  <StarsIcon sx={{ fontSize: '0.95rem' }} />
+                </div>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      </Popover>
 
       {showUploadButton ? (
         <button

--- a/app/showdatabase/DatabaseItem.tsx
+++ b/app/showdatabase/DatabaseItem.tsx
@@ -8,7 +8,6 @@ import { trpc } from 'lib/trpc/client';
 // components
 import AreYouSure from '@/shared/AreYouSure';
 import Button from '@/components/ui/Button';
-import { blockClasses } from '@/mediacollector/CollectedCoversBlock';
 import EditDatabaseBlock from '@/showdatabase/EditDatabaseBlock';
 
 // helpers
@@ -21,6 +20,7 @@ import { useDatabasePageContext } from 'lib/context/DatabasePageContext';
 import { PostSavedMediaItem } from 'lib/interfaces/globalInterfaces';
 import { isBookRow } from 'lib/helpers/handleMediaTyping';
 import { MEDIA_TYPES } from 'lib/constants/mediaTypes';
+import { blockClasses } from 'lib/constants/typeBlockStyles';
 
 export interface DatabaseItemProps {
   info: PostSavedMediaItem;
@@ -42,9 +42,9 @@ const DatabaseItem = memo(function DatabaseItem({ info }: DatabaseItemProps) {
   const [areYouSure, setAreYouSure] = useState(false);
   const [edit, setEdit] = useState(false);
   const [genres, setGenres] = useState<string[]>([]);
-  const [brokenImageUrls, setBrokenImageUrls] = useState<Record<string, boolean>>(
-    {},
-  );
+  const [brokenImageUrls, setBrokenImageUrls] = useState<
+    Record<string, boolean>
+  >({});
   //   const [deleteError, setDeleteError] = useState<string | undefined>();
 
   //on mount, get the genres related to the displayed book and make sure to update if the item is edited
@@ -77,7 +77,7 @@ const DatabaseItem = memo(function DatabaseItem({ info }: DatabaseItemProps) {
 
   return (
     <div
-      className={`mr-auto box-border flex w-full items-center justify-start rounded-sm border-2 p-2 ${blockClasses[itemType]}`}
+      className={`mr-auto box-border flex w-full items-center justify-start rounded-sm p-2 ${blockClasses[itemType]}`}
     >
       {areYouSure && (
         <AreYouSure

--- a/app/showdatabase/DatabaseItem.tsx
+++ b/app/showdatabase/DatabaseItem.tsx
@@ -9,6 +9,7 @@ import { trpc } from 'lib/trpc/client';
 import AreYouSure from '@/shared/AreYouSure';
 import Button from '@/components/ui/Button';
 import EditDatabaseBlock from '@/showdatabase/EditDatabaseBlock';
+import MediaImageStrip from '@/shared/MediaImageStrip';
 
 // helpers
 import { titleRearrange } from 'lib/helpers/titleRearrange';
@@ -33,7 +34,7 @@ const DatabaseItem = memo(function DatabaseItem({ info }: DatabaseItemProps) {
     handleGetMedia,
   } = useDatabasePageContext();
 
-  const { id, title, spineColor, imageUrls } = info;
+  const { id, title, spineColor, images } = info;
   const itemType =
     MEDIA_TYPES.find((mediaType) => mediaType === info.mediaType) ??
     displayedListType;
@@ -42,9 +43,6 @@ const DatabaseItem = memo(function DatabaseItem({ info }: DatabaseItemProps) {
   const [areYouSure, setAreYouSure] = useState(false);
   const [edit, setEdit] = useState(false);
   const [genres, setGenres] = useState<string[]>([]);
-  const [brokenImageUrls, setBrokenImageUrls] = useState<
-    Record<string, boolean>
-  >({});
   //   const [deleteError, setDeleteError] = useState<string | undefined>();
 
   //on mount, get the genres related to the displayed book and make sure to update if the item is edited
@@ -93,7 +91,7 @@ const DatabaseItem = memo(function DatabaseItem({ info }: DatabaseItemProps) {
             // isBookRow(type, info)
             {
               type: itemType,
-              images: imageUrls ?? [],
+              images: images ?? [],
               blockInfo: {
                 title,
                 author: bookDetails?.author,
@@ -128,33 +126,13 @@ const DatabaseItem = memo(function DatabaseItem({ info }: DatabaseItemProps) {
         <></>
       )}
 
-      {imageUrls?.map((src, idx) => (
-        <div
-          key={idx}
-          className={
-            itemType === 'album'
-              ? 'mr-7 h-36 w-36 rounded-sm'
-              : 'mr-7 ml-2 h-36 w-24 rounded-sm'
-          }
-        >
-          {brokenImageUrls[src] ? (
-            <div className="flex h-full w-full items-center justify-center rounded-sm bg-red-600/65 p-2 text-center text-sm font-bold text-white">
-              Image path broken
-            </div>
-          ) : (
-            <img
-              className="h-full w-full rounded-sm"
-              src={src}
-              onError={() =>
-                setBrokenImageUrls((previous) => ({
-                  ...previous,
-                  [src]: true,
-                }))
-              }
-            ></img>
-          )}
-        </div>
-      ))}
+      <MediaImageStrip
+        mediaType={itemType}
+        images={images ?? []}
+        className="mr-7 ml-2 flex flex-row items-center gap-3"
+        albumTileClassName="relative z-10 h-36 w-24 overflow-hidden rounded-sm"
+        defaultTileClassName="relative z-10 h-36 w-24 overflow-hidden rounded-sm"
+      />
       {itemType === 'book' && bookDetails ? (
         <div className="flex flex-col">
           <p className="text-3xl">{titleRearrange(title)}</p>

--- a/app/showdatabase/EditDatabaseBlock.tsx
+++ b/app/showdatabase/EditDatabaseBlock.tsx
@@ -1,11 +1,13 @@
 // react, redux imports
-import { Dispatch, memo, SetStateAction, useContext, useState } from 'react';
-
-//import icons and items from Material UI
-import BookIcon from '@mui/icons-material/BookTwoTone';
-import MovieIcon from '@mui/icons-material/LocalMoviesTwoTone';
-import VideoGameIcon from '@mui/icons-material/VideogameAssetTwoTone';
-import AlbumIcon from '@mui/icons-material/AlbumTwoTone';
+import {
+  ChangeEvent,
+  Dispatch,
+  memo,
+  SetStateAction,
+  useContext,
+  useRef,
+  useState,
+} from 'react';
 
 // context
 import GenreContext from 'lib/context/GenreContext';
@@ -14,17 +16,18 @@ import { useDatabasePageContext } from 'lib/context/DatabasePageContext';
 // components
 import GenreCheckboxes from '@/mediacollector/GenreCheckboxes';
 import Button from '@/components/ui/Button';
+import MediaImageStrip from '@/shared/MediaImageStrip';
 
 // library imports
 import { trpc } from 'lib/trpc/client';
 
 // helpers
 import { titleRearrange } from 'lib/helpers/titleRearrange';
-import { blockClasses } from '@/mediacollector/CollectedCoversBlock';
 
 // interfaces and types
 import { BlockInfo, PostSavedMediaItem } from 'lib/interfaces/globalInterfaces';
 import { MediaType } from 'lib/constants/mediaTypes';
+import { blockClasses, icons } from 'lib/constants/typeBlockStyles';
 
 export interface MinimalTextAreaProps {
   name: 'title' | 'author' | 'pubYear' | 'pageCount';
@@ -113,16 +116,8 @@ const EditDatabaseBlock = memo(function EditDatabaseBlock({
 
   const [databaseGenres, setDatabaseGenres] = useState([...initialGenres]);
   const [color, setColor] = useState(spineColor);
-
-  //establish variables for icons
-  const icons = {
-    book: <BookIcon sx={{ position: 'absolute', top: '4px', left: '4px' }} />,
-    movie: <MovieIcon sx={{ position: 'absolute', top: '4px', left: '4px' }} />,
-    videoGame: (
-      <VideoGameIcon sx={{ position: 'absolute', top: '4px', left: '4px' }} />
-    ),
-    album: <AlbumIcon sx={{ position: 'absolute', top: '4px', left: '4px' }} />,
-  };
+  const [isUploading, setIsUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   //get genres for checkbox population
   const genres = useContext(GenreContext);
@@ -156,9 +151,54 @@ const EditDatabaseBlock = memo(function EditDatabaseBlock({
   };
 
   const { mutateAsync: databaseEdit } = trpc.database.edit.useMutation();
+  const { mutateAsync: uploadCoverImage } =
+    trpc.collect.uploadCoverImage.useMutation();
   const { mutateAsync: linkGenres } = trpc.genres.link.useMutation();
   const { mutateAsync: unlinkGenres } = trpc.genres.unlink.useMutation();
   const utils = trpc.useUtils();
+
+  const convertFileToBase64 = (file: File): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result;
+        if (typeof result !== 'string') {
+          reject(new Error('Unable to read uploaded file.'));
+          return;
+        }
+        const [, dataBase64 = ''] = result.split(',');
+        resolve(dataBase64);
+      };
+      reader.onerror = () => {
+        reject(new Error('Unable to read uploaded file.'));
+      };
+      reader.readAsDataURL(file);
+    });
+
+  const handleUploadImage = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    setIsUploading(true);
+    try {
+      const dataBase64 = await convertFileToBase64(file);
+      const { url } = await uploadCoverImage({
+        blockID: id,
+        sortOrder: databaseData.imageUrls.length,
+        fileName: file.name,
+        mimeType: file.type,
+        dataBase64,
+      });
+      setDatabaseData((prev) => ({ ...prev, imageUrls: [...prev.imageUrls, url] }));
+    } catch (error) {
+      console.error('Failed to upload image for database edit', error);
+    } finally {
+      setIsUploading(false);
+      event.target.value = '';
+    }
+  };
 
   const handleEditSubmit = async () => {
     const res = await databaseEdit({ type, item: databaseData });
@@ -206,23 +246,29 @@ const EditDatabaseBlock = memo(function EditDatabaseBlock({
       <h1>Editing: {titleRearrange(title)}</h1>
 
       <div
-        className={`relative flex h-fit w-fit flex-col items-center gap-2.5 rounded-lg border-2 text-lg ${blockClasses[type]} mb-1`}
+        className={`relative flex h-fit w-fit min-w-lg flex-col items-center gap-2.5 rounded-lg text-lg ${blockClasses[type]} mb-1`}
       >
-        {icons[type]}
-        <div className="m-2.5 mb-0 flex flex-row items-center gap-7.5">
-          {images.map((src) => (
-            <div className="relative z-10 overflow-hidden rounded-sm" key={src}>
-              <img
-                className={
-                  type === 'album'
-                    ? 'block w-21 cursor-pointer object-cover outline-2'
-                    : 'block h-31 w-21 cursor-pointer'
-                }
-                src={src}
-              ></img>
-            </div>
-          ))}
-        </div>
+        <div className="absolute top-1 left-1">{icons[type]}</div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleUploadImage}
+          aria-label="Upload database image"
+        />
+        <MediaImageStrip
+          mediaType={type}
+          images={databaseData.imageUrls.map((url) => ({ url }))}
+          className="m-2.5 mb-0 flex flex-row items-center gap-7.5"
+          albumTileClassName="relative z-10 h-31 w-21 overflow-hidden rounded-sm"
+          defaultTileClassName="relative z-10 h-31 w-21 overflow-hidden rounded-sm"
+          showUploadButton={type === 'book'}
+          isUploading={isUploading}
+          onUploadButtonClick={() => fileInputRef.current?.click()}
+          uploadButtonLabel="Add uploaded database image"
+          uploadSlotLabel="Uploading..."
+        />
         {type !== 'album' ? (
           <div
             className="h-5 w-1/2 cursor-pointer"

--- a/app/showdatabase/EditDatabaseBlock.tsx
+++ b/app/showdatabase/EditDatabaseBlock.tsx
@@ -40,7 +40,7 @@ export interface MinimalTextAreaProps {
 export interface EditDatabaseBlockProps {
   info: {
     type: MediaType;
-    images: string[];
+    images: PostSavedMediaItem['images'];
     blockInfo: Omit<BlockInfo, 'databaseGenres'> & { initialGenres: string[] };
     id: string;
     setEdit: Dispatch<SetStateAction<boolean>>;
@@ -108,7 +108,17 @@ const EditDatabaseBlock = memo(function EditDatabaseBlock({
     pubYear,
     pageCount,
     spineColor,
-    imageUrls: images,
+    images:
+      images.length > 0
+        ? images
+        : [
+            {
+              url: '/images/placeholder-image.png',
+              isDefault: true,
+              selected: true,
+              spineColor,
+            },
+          ],
   };
 
   const [databaseData, setDatabaseData] =
@@ -123,6 +133,47 @@ const EditDatabaseBlock = memo(function EditDatabaseBlock({
   const genres = useContext(GenreContext);
   const { handleGetMedia } = useDatabasePageContext();
 
+  const defaultImageIndex = Math.max(
+    databaseData.images.findIndex((image) => image.isDefault),
+    0,
+  );
+  const selectedImageIndex = databaseData.images.findIndex((image) => image.selected);
+  const pendingDefaultImageIndex =
+    selectedImageIndex >= 0 && selectedImageIndex !== defaultImageIndex
+      ? selectedImageIndex
+      : null;
+
+  const handleImageSelection = (imageIndex: number) => {
+    const selectedImage = databaseData.images[imageIndex];
+    if (!selectedImage) {
+      return;
+    }
+    setColor(selectedImage.spineColor);
+    setDatabaseData((prev) => ({
+      ...prev,
+      spineColor: selectedImage.spineColor,
+      images: prev.images.map((image, index) => ({
+        ...image,
+        selected: index === imageIndex,
+      })),
+    }));
+  };
+
+  const handleSetAsDefault = () => {
+    if (pendingDefaultImageIndex == null) {
+      return;
+    }
+    setDatabaseData((prev) => ({
+      ...prev,
+      spineColor: prev.images[pendingDefaultImageIndex]?.spineColor ?? prev.spineColor,
+      images: prev.images.map((image, index) => ({
+        ...image,
+        isDefault: index === pendingDefaultImageIndex,
+        selected: index === pendingDefaultImageIndex,
+      })),
+    }));
+  };
+
   //div under the covers to pick a color for the spine.
   //this is used in png creation and is required for the database row
   const handleColorPick = async () => {
@@ -135,7 +186,19 @@ const EditDatabaseBlock = memo(function EditDatabaseBlock({
       const { sRGBHex } = await eyeDropper.open();
       const spineColor = sRGBHex;
       setColor(spineColor);
-      setDatabaseData((prev) => ({ ...prev, spineColor: spineColor }));
+      setDatabaseData((prev) => {
+        const imageIndexToUpdate =
+          prev.images.findIndex((image) => image.selected) >= 0
+            ? prev.images.findIndex((image) => image.selected)
+            : defaultImageIndex;
+        return {
+          ...prev,
+          spineColor: spineColor,
+          images: prev.images.map((image, index) =>
+            index === imageIndexToUpdate ? { ...image, spineColor } : image,
+          ),
+        };
+      });
     } catch (e) {
       console.log(e);
     }
@@ -184,14 +247,26 @@ const EditDatabaseBlock = memo(function EditDatabaseBlock({
     setIsUploading(true);
     try {
       const dataBase64 = await convertFileToBase64(file);
-      const { url } = await uploadCoverImage({
+      const uploadedImage = await uploadCoverImage({
         blockID: id,
-        sortOrder: databaseData.imageUrls.length,
+        sortOrder: databaseData.images.length,
         fileName: file.name,
         mimeType: file.type,
         dataBase64,
       });
-      setDatabaseData((prev) => ({ ...prev, imageUrls: [...prev.imageUrls, url] }));
+      setDatabaseData((prev) => ({
+        ...prev,
+        spineColor: color,
+        images: [
+          ...prev.images.map((image) => ({ ...image, selected: false })),
+          {
+            url: uploadedImage.url,
+            selected: true,
+            isDefault: false,
+            spineColor: color,
+          },
+        ],
+      }));
     } catch (error) {
       console.error('Failed to upload image for database edit', error);
     } finally {
@@ -259,10 +334,12 @@ const EditDatabaseBlock = memo(function EditDatabaseBlock({
         />
         <MediaImageStrip
           mediaType={type}
-          images={databaseData.imageUrls.map((url) => ({ url }))}
+          images={databaseData.images}
           className="m-2.5 mb-0 flex flex-row items-center gap-7.5"
           albumTileClassName="relative z-10 h-31 w-21 overflow-hidden rounded-sm"
           defaultTileClassName="relative z-10 h-31 w-21 overflow-hidden rounded-sm"
+          showSelectionOverlay
+          onImageClick={handleImageSelection}
           showUploadButton={type === 'book'}
           isUploading={isUploading}
           onUploadButtonClick={() => fileInputRef.current?.click()}
@@ -338,6 +415,15 @@ const EditDatabaseBlock = memo(function EditDatabaseBlock({
           width={150}
           fontSize={25}
         />
+        {pendingDefaultImageIndex != null ? (
+          <Button
+            variant="primary"
+            label="Set as Default"
+            onClick={handleSetAsDefault}
+            width={165}
+            fontSize={25}
+          />
+        ) : null}
       </div>
     </div>
   );

--- a/lib/constants/typeBlockStyles.tsx
+++ b/lib/constants/typeBlockStyles.tsx
@@ -1,0 +1,19 @@
+import BookIcon from '@mui/icons-material/BookTwoTone';
+import MovieIcon from '@mui/icons-material/LocalMoviesTwoTone';
+import VideoGameIcon from '@mui/icons-material/VideogameAssetTwoTone';
+import AlbumIcon from '@mui/icons-material/AlbumTwoTone';
+
+export const blockClasses = {
+    book: 'bg-[#e1b3b5]',
+    movie: 'bg-[#323b43] text-white',
+    album: 'bg-[#7fa5a3]',
+    videoGame: 'bg-[#98ab88]',
+    hasError: 'bg-[#E86C54]',
+  };
+
+  export const icons = {
+    book: <BookIcon />,
+    movie: <MovieIcon />,
+    videoGame: <VideoGameIcon />,
+    album: <AlbumIcon />,
+  };

--- a/lib/interfaces/globalInterfaces.ts
+++ b/lib/interfaces/globalInterfaces.ts
@@ -19,6 +19,13 @@ interface MediaExtras {
   genres?: string[];
 }
 
+export interface MediaImageItem {
+  url: string;
+  selected?: boolean;
+  isDefault: boolean;
+  spineColor: string;
+}
+
 export type BookInsert = Omit<InferInsertModel<typeof books>, 'id'> &
   MediaExtras;
 export type OtherMediaInsert = Omit<InferInsertModel<typeof otherMedia>, 'id'> &
@@ -34,7 +41,7 @@ export interface PostSavedMediaItem {
   id: string;
   title: string;
   spineColor: string;
-  imageUrls: string[];
+  images: MediaImageItem[];
   mediaType?: string;
   author?: string;
   pageCount?: number | null;

--- a/lib/media-storage/image-path-utils.ts
+++ b/lib/media-storage/image-path-utils.ts
@@ -38,6 +38,18 @@ export function isLocalImagePath(imageUrl: string): boolean {
   );
 }
 
-export function normalizeImagePath(imageUrl: string): string {
-  return imageUrl.trim();
+export function normalizeImagePath(imageUrl: unknown): string {
+  if (typeof imageUrl === 'string') {
+    return imageUrl.trim();
+  }
+  if (imageUrl && typeof imageUrl === 'object') {
+    const record = imageUrl as { url?: unknown; src?: unknown };
+    if (typeof record.url === 'string') {
+      return record.url.trim();
+    }
+    if (typeof record.src === 'string') {
+      return record.src.trim();
+    }
+  }
+  return '';
 }

--- a/lib/media-storage/local-image-storage.ts
+++ b/lib/media-storage/local-image-storage.ts
@@ -36,6 +36,15 @@ export type PersistExternalImageInput = {
   sortOrder: number;
 };
 
+export type PersistUploadedImageInput = {
+  imageBuffer: Buffer;
+  mediaType: MediaType;
+  mediaId: string;
+  sortOrder: number;
+  mimeType?: string;
+  fileName?: string;
+};
+
 type S3StorageConfig = {
   client: S3Client;
   bucket: string;
@@ -100,6 +109,19 @@ function normalizePathSegment(segment: string | undefined): string {
     return '';
   }
   return segment.trim().replace(/^\/+|\/+$/g, '');
+}
+
+function sanitizeFileNameSegment(fileName: string | undefined): string {
+  if (!fileName) {
+    return 'upload';
+  }
+  const withoutExtension = fileName.replace(/\.[^./\\]+$/, '');
+  const sanitized = withoutExtension
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return sanitized || 'upload';
 }
 
 function getRequiredEnvValue(name: string): string {
@@ -274,6 +296,77 @@ export async function persistExternalImageToS3(
     mimeType,
     sizeBytes: imageBuffer.length,
     sourceUrl,
+  };
+}
+
+export async function persistUploadedImageToS3(
+  input: PersistUploadedImageInput,
+): Promise<PersistedImageFile> {
+  const imageBuffer = input.imageBuffer;
+  if (!imageBuffer || imageBuffer.length === 0) {
+    throw new Error('Uploaded image is empty.');
+  }
+  const maxImageBytes = getMaxImageBytes();
+  if (imageBuffer.length > maxImageBytes) {
+    throw new Error(
+      `Uploaded image exceeded MAX_IMAGE_BYTES (${imageBuffer.length} bytes).`,
+    );
+  }
+
+  const detectedFileType = await detectFileTypeFromBuffer(imageBuffer);
+  const inputMimeType = resolveMimeType(input.mimeType);
+  const mimeType = detectedFileType?.mime ?? inputMimeType ?? null;
+  const allowedMimeTypes = getAllowedMimeTypes();
+  if (!mimeType || !allowedMimeTypes.includes(mimeType)) {
+    throw new Error(
+      `Image MIME type is not allowed for upload. Received "${mimeType ?? 'unknown'}".`,
+    );
+  }
+
+  const extension = detectedFileType?.ext ?? resolveExtension(mimeType);
+  if (!extension) {
+    throw new Error('Unable to resolve file extension for uploaded image.');
+  }
+
+  const now = new Date();
+  const year = String(now.getUTCFullYear());
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const uploadNamespace = getUploadNamespace();
+  const fileHash = createHash('sha256')
+    .update(imageBuffer)
+    .digest('hex')
+    .slice(0, 16);
+  const orderToken = String(input.sortOrder).padStart(2, '0');
+  const fileLabel = sanitizeFileNameSegment(input.fileName);
+  const fileName = `${input.mediaType}-${input.mediaId}-${orderToken}-${fileLabel}-${fileHash}.${extension}`;
+
+  const s3Config = getS3StorageConfig();
+  const objectKey = [
+    s3Config.keyPrefix,
+    uploadNamespace,
+    'covers',
+    year,
+    month,
+    fileName,
+  ]
+    .filter(Boolean)
+    .join('/');
+
+  await s3Config.client.send(
+    new PutObjectCommand({
+      Bucket: s3Config.bucket,
+      Key: objectKey,
+      Body: imageBuffer,
+      ContentType: mimeType,
+      CacheControl: 'public, max-age=31536000, immutable',
+    }),
+  );
+
+  return {
+    publicPath: `${s3Config.publicBaseUrl}/${objectKey}`,
+    mimeType,
+    sizeBytes: imageBuffer.length,
+    sourceUrl: input.fileName?.trim() || 'uploaded-image',
   };
 }
 

--- a/lib/media-storage/media-image-records.ts
+++ b/lib/media-storage/media-image-records.ts
@@ -19,14 +19,21 @@ export type ImageResolutionResult = {
 
 export async function resolveAndPersistImageList(
   mediaReference: ParentMediaReference,
-  sourceImageUrls: string[],
+  sourceImageUrls: unknown[],
 ): Promise<ImageResolutionResult> {
   const images: PersistedImageFile[] = [];
   const failures: Array<{ sourceUrl: string; message: string }> = [];
 
   for (let index = 0; index < sourceImageUrls.length; index += 1) {
-    const sourceUrl = normalizeImagePath(sourceImageUrls[index] ?? '');
+    const rawSourceUrl = sourceImageUrls[index];
+    const sourceUrl = normalizeImagePath(rawSourceUrl ?? '');
     if (!sourceUrl) {
+      if (!(rawSourceUrl == null || rawSourceUrl === '')) {
+        failures.push({
+          sourceUrl: '',
+          message: 'Invalid image payload. Expected an image URL string.',
+        });
+      }
       continue;
     }
 

--- a/lib/media-storage/media-image-records.ts
+++ b/lib/media-storage/media-image-records.ts
@@ -3,6 +3,7 @@ import { and, asc, eq, inArray, isNull } from 'drizzle-orm';
 import { mediaImageItems } from '@/db/schema';
 import { MediaType } from 'lib/constants/mediaTypes';
 import { normalizeImagePath } from './image-path-utils';
+import { MediaImageItem } from 'lib/interfaces/globalInterfaces';
 import {
   PersistedImageFile,
   persistExternalImageToS3,
@@ -13,22 +14,78 @@ type ParentMediaReference =
   | { mediaType: Exclude<MediaType, 'book'>; mediaId: string };
 
 export type ImageResolutionResult = {
-  images: PersistedImageFile[];
+  images: PersistedMediaImageRecord[];
   failures: Array<{ sourceUrl: string; message: string }>;
 };
 
+export type SourceImageItem =
+  | string
+  | {
+      url: string;
+      isDefault?: boolean;
+      spineColor?: string;
+    };
+
+export type PersistedMediaImageRecord = PersistedImageFile & {
+  isDefault: boolean;
+  spineColor: string;
+};
+
+function normalizeSourceImage(
+  rawSourceImage: unknown,
+  fallbackSpineColor: string,
+): SourceImageItem | null {
+  if (typeof rawSourceImage === 'string') {
+    return rawSourceImage;
+  }
+  if (
+    typeof rawSourceImage === 'object' &&
+    rawSourceImage !== null &&
+    'url' in rawSourceImage &&
+    typeof rawSourceImage.url === 'string'
+  ) {
+    const imageRecord = rawSourceImage as {
+      url: string;
+      isDefault?: boolean;
+      spineColor?: string;
+    };
+    return {
+      url: imageRecord.url,
+      isDefault: imageRecord.isDefault ?? false,
+      spineColor: imageRecord.spineColor ?? fallbackSpineColor,
+    };
+  }
+  return null;
+}
+
 export async function resolveAndPersistImageList(
   mediaReference: ParentMediaReference,
-  sourceImageUrls: unknown[],
+  sourceImages: unknown[],
+  options?: { defaultSpineColor?: string; defaultImageIndex?: number },
 ): Promise<ImageResolutionResult> {
-  const images: PersistedImageFile[] = [];
+  const images: PersistedMediaImageRecord[] = [];
   const failures: Array<{ sourceUrl: string; message: string }> = [];
+  const fallbackSpineColor = options?.defaultSpineColor ?? '#ffffff';
+  const defaultImageIndex = options?.defaultImageIndex ?? 0;
 
-  for (let index = 0; index < sourceImageUrls.length; index += 1) {
-    const rawSourceUrl = sourceImageUrls[index];
-    const sourceUrl = normalizeImagePath(rawSourceUrl ?? '');
+  const normalizedSourceImages = sourceImages
+    .map((sourceImage) => normalizeSourceImage(sourceImage, fallbackSpineColor))
+    .filter((sourceImage): sourceImage is SourceImageItem => sourceImage !== null);
+  const explicitDefaultIndex = normalizedSourceImages.findIndex(
+    (sourceImage) =>
+      typeof sourceImage === 'object' &&
+      sourceImage !== null &&
+      sourceImage.isDefault === true,
+  );
+  const resolvedDefaultIndex = explicitDefaultIndex >= 0 ? explicitDefaultIndex : defaultImageIndex;
+
+  for (let index = 0; index < normalizedSourceImages.length; index += 1) {
+    const rawSourceImage = normalizedSourceImages[index];
+    const sourceUrl = normalizeImagePath(
+      typeof rawSourceImage === 'string' ? rawSourceImage : rawSourceImage.url,
+    );
     if (!sourceUrl) {
-      if (!(rawSourceUrl == null || rawSourceUrl === '')) {
+      if (!(rawSourceImage == null || rawSourceImage === '')) {
         failures.push({
           sourceUrl: '',
           message: 'Invalid image payload. Expected an image URL string.',
@@ -44,7 +101,15 @@ export async function resolveAndPersistImageList(
         mediaId: mediaReference.mediaId,
         sortOrder: index,
       });
-      images.push(persistedImage);
+      const spineColor =
+        typeof rawSourceImage === 'object' && rawSourceImage.spineColor
+          ? rawSourceImage.spineColor
+          : fallbackSpineColor;
+      images.push({
+        ...persistedImage,
+        isDefault: index === resolvedDefaultIndex,
+        spineColor,
+      });
     } catch (error) {
       const message =
         error instanceof Error
@@ -60,7 +125,7 @@ export async function resolveAndPersistImageList(
 export async function replaceBookImageRecords(
   db: Db,
   bookId: string,
-  imageFiles: PersistedImageFile[],
+  imageFiles: PersistedMediaImageRecord[],
 ) {
   await db.delete(mediaImageItems).where(eq(mediaImageItems.bookId, bookId));
 
@@ -76,6 +141,8 @@ export async function replaceBookImageRecords(
       mimeType: imageFile.mimeType,
       sizeBytes: imageFile.sizeBytes,
       sortOrder,
+      isDefault: imageFile.isDefault,
+      spineColor: imageFile.spineColor,
     })),
   );
 }
@@ -83,7 +150,7 @@ export async function replaceBookImageRecords(
 export async function replaceOtherMediaImageRecords(
   db: Db,
   otherMediaId: string,
-  imageFiles: PersistedImageFile[],
+  imageFiles: PersistedMediaImageRecord[],
 ) {
   await db
     .delete(mediaImageItems)
@@ -101,13 +168,15 @@ export async function replaceOtherMediaImageRecords(
       mimeType: imageFile.mimeType,
       sizeBytes: imageFile.sizeBytes,
       sortOrder,
+      isDefault: imageFile.isDefault,
+      spineColor: imageFile.spineColor,
     })),
   );
 }
 
-export async function loadBookImageUrlsById(db: Db, bookIds: string[]) {
+export async function loadBookImagesById(db: Db, bookIds: string[]) {
   if (bookIds.length === 0) {
-    return new Map<string, string[]>();
+    return new Map<string, MediaImageItem[]>();
   }
 
   const rows = await db
@@ -115,6 +184,8 @@ export async function loadBookImageUrlsById(db: Db, bookIds: string[]) {
       bookId: mediaImageItems.bookId,
       path: mediaImageItems.path,
       sortOrder: mediaImageItems.sortOrder,
+      isDefault: mediaImageItems.isDefault,
+      spineColor: mediaImageItems.spineColor,
     })
     .from(mediaImageItems)
     .where(
@@ -125,22 +196,27 @@ export async function loadBookImageUrlsById(db: Db, bookIds: string[]) {
     )
     .orderBy(asc(mediaImageItems.sortOrder));
 
-  const imageUrlsByBookId = new Map<string, string[]>();
+  const imagesByBookId = new Map<string, MediaImageItem[]>();
   for (const row of rows) {
     const bookId = row.bookId;
     if (!bookId) {
       continue;
     }
-    const currentList = imageUrlsByBookId.get(bookId) ?? [];
-    currentList.push(row.path);
-    imageUrlsByBookId.set(bookId, currentList);
+    const currentList = imagesByBookId.get(bookId) ?? [];
+    currentList.push({
+      url: row.path,
+      isDefault: row.isDefault,
+      spineColor: row.spineColor,
+      selected: false,
+    });
+    imagesByBookId.set(bookId, currentList);
   }
-  return imageUrlsByBookId;
+  return imagesByBookId;
 }
 
-export async function loadOtherMediaImageUrlsById(db: Db, otherMediaIds: string[]) {
+export async function loadOtherMediaImagesById(db: Db, otherMediaIds: string[]) {
   if (otherMediaIds.length === 0) {
-    return new Map<string, string[]>();
+    return new Map<string, MediaImageItem[]>();
   }
 
   const rows = await db
@@ -148,6 +224,8 @@ export async function loadOtherMediaImageUrlsById(db: Db, otherMediaIds: string[
       otherMediaId: mediaImageItems.otherMediaId,
       path: mediaImageItems.path,
       sortOrder: mediaImageItems.sortOrder,
+      isDefault: mediaImageItems.isDefault,
+      spineColor: mediaImageItems.spineColor,
     })
     .from(mediaImageItems)
     .where(
@@ -158,15 +236,40 @@ export async function loadOtherMediaImageUrlsById(db: Db, otherMediaIds: string[
     )
     .orderBy(asc(mediaImageItems.sortOrder));
 
-  const imageUrlsByOtherMediaId = new Map<string, string[]>();
+  const imagesByOtherMediaId = new Map<string, MediaImageItem[]>();
   for (const row of rows) {
     const otherMediaId = row.otherMediaId;
     if (!otherMediaId) {
       continue;
     }
-    const currentList = imageUrlsByOtherMediaId.get(otherMediaId) ?? [];
-    currentList.push(row.path);
-    imageUrlsByOtherMediaId.set(otherMediaId, currentList);
+    const currentList = imagesByOtherMediaId.get(otherMediaId) ?? [];
+    currentList.push({
+      url: row.path,
+      isDefault: row.isDefault,
+      spineColor: row.spineColor,
+      selected: false,
+    });
+    imagesByOtherMediaId.set(otherMediaId, currentList);
   }
-  return imageUrlsByOtherMediaId;
+  return imagesByOtherMediaId;
+}
+
+export async function loadBookImageUrlsById(db: Db, bookIds: string[]) {
+  const imagesByBookId = await loadBookImagesById(db, bookIds);
+  return new Map(
+    [...imagesByBookId.entries()].map(([bookId, images]) => [
+      bookId,
+      images.map((image) => image.url),
+    ]),
+  );
+}
+
+export async function loadOtherMediaImageUrlsById(db: Db, otherMediaIds: string[]) {
+  const imagesByOtherMediaId = await loadOtherMediaImagesById(db, otherMediaIds);
+  return new Map(
+    [...imagesByOtherMediaId.entries()].map(([otherMediaId, images]) => [
+      otherMediaId,
+      images.map((image) => image.url),
+    ]),
+  );
 }

--- a/lib/trpc/routers/collect/_.ts
+++ b/lib/trpc/routers/collect/_.ts
@@ -45,7 +45,12 @@ export const collectRouter = router({
         mimeType: input.mimeType,
       });
 
-      return { url: uploadedImage.publicPath };
+      return {
+        url: uploadedImage.publicPath,
+        isDefault: input.sortOrder === 0,
+        spineColor: '#ffffff',
+        selected: true,
+      };
     }),
   collectMedia: adminProcedure
     .input(
@@ -104,13 +109,26 @@ export const collectRouter = router({
               }
               const {
                 id,
-                imageUrls,
                 title: foundTitle,
                 author,
                 pageCount,
                 pubYear,
                 spineColor,
               } = foundMedia;
+              const normalizedImages =
+                'images' in foundMedia && Array.isArray(foundMedia.images)
+                  ? foundMedia.images
+                  : ('imageUrls' in foundMedia && Array.isArray(foundMedia.imageUrls)
+                      ? foundMedia.imageUrls.map((url) => ({
+                          url,
+                          isDefault: false,
+                          spineColor,
+                          selected: false,
+                        }))
+                      : []);
+              if (normalizedImages.length > 0 && !normalizedImages.some((image) => image.isDefault)) {
+                normalizedImages[0] = { ...normalizedImages[0], isDefault: true };
+              }
               const rows = await db
                 .select({ genre: genres.genre })
                 .from(genres)
@@ -121,27 +139,55 @@ export const collectRouter = router({
 
               blocks.push({
                 type: 'book',
-                images: imageUrls.map((url) => ({ url, selected: false })),
+                images: normalizedImages.map((image) => ({
+                  ...image,
+                  selected: image.isDefault,
+                  spineColor: image.spineColor,
+                })),
                 blockInfo: {
                   title: foundTitle,
                   author,
                   pubYear,
                   pageCount,
-                  spineColor,
+                  spineColor:
+                    normalizedImages.find((image) => image.isDefault)?.spineColor ??
+                    normalizedImages[0]?.spineColor ??
+                    spineColor,
                   genres: databaseGenres,
                 },
                 blockID: `BLK-${Math.random().toString(36).slice(2, 10).toUpperCase()}`,
                 isDatabase: true,
               });
             } else {
-              const { imageUrls, title: foundTitle, spineColor } = foundMedia;
+              const { title: foundTitle, spineColor } = foundMedia;
+              const normalizedImages =
+                'images' in foundMedia && Array.isArray(foundMedia.images)
+                  ? foundMedia.images
+                  : ('imageUrls' in foundMedia && Array.isArray(foundMedia.imageUrls)
+                      ? foundMedia.imageUrls.map((url) => ({
+                          url,
+                          isDefault: false,
+                          spineColor,
+                          selected: false,
+                        }))
+                      : []);
+              if (normalizedImages.length > 0 && !normalizedImages.some((image) => image.isDefault)) {
+                normalizedImages[0] = { ...normalizedImages[0], isDefault: true };
+              }
 
               blocks.push({
                 type,
-                images: imageUrls.map((url) => ({ url, selected: false })),
+                images: normalizedImages.map((image) => ({
+                  ...image,
+                  selected: image.isDefault,
+                  spineColor: image.spineColor,
+                })),
                 blockInfo: {
                   title: foundTitle,
-                  spineColor,
+                  spineColor:
+                    normalizedImages.find((image) => image.isDefault)?.spineColor ??
+                    normalizedImages[0]?.spineColor ??
+                    spineColor,
                   genres: [],
                 },
                 blockID: `BLK-${Math.random().toString(36).slice(2, 10).toUpperCase()}`,
@@ -157,7 +203,12 @@ export const collectRouter = router({
               const bookInfo = await getOpenLibraryData(title, author);
               blocks.push({
                 type,
-                images: images.map((url) => ({ url, selected: false })),
+                images: images.map((url, index) => ({
+                  url,
+                  selected: index === 0,
+                  isDefault: index === 0,
+                  spineColor: '#ffffff',
+                })),
                 blockInfo: { ...bookInfo, spineColor: '#ffffff', genres: [] },
                 blockID: `BLK-${Math.random().toString(36).slice(2, 10).toUpperCase()}`,
                 isDatabase: false,
@@ -165,7 +216,12 @@ export const collectRouter = router({
             } else {
               blocks.push({
                 type,
-                images: images.map((url) => ({ url, selected: false })),
+                images: images.map((url, index) => ({
+                  url,
+                  selected: index === 0,
+                  isDefault: index === 0,
+                  spineColor: '#ffffff',
+                })),
                 blockInfo: { title, spineColor: '#ffffff', genres: [] },
                 blockID: `BLK-${Math.random().toString(36).slice(2, 10).toUpperCase()}`,
                 isDatabase: false,

--- a/lib/trpc/routers/collect/_.ts
+++ b/lib/trpc/routers/collect/_.ts
@@ -1,4 +1,5 @@
 import { adminProcedure, router } from 'lib/trpc/trpc';
+import { TRPCError } from '@trpc/server';
 import { eq, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import { db as defaultDb } from '@/db/client';
@@ -10,11 +11,42 @@ import { getMediaCovers } from './actions/get-media-covers';
 import { searchByTitle } from '../database/actions/search-by-title';
 import { googleApiQueryUsage } from '@/db/schema';
 import { collectedBlockInformationSchema } from '@/mediacollector/collector-form/collectorFormSchema';
+import { persistUploadedImageToS3 } from 'lib/media-storage/local-image-storage';
 export type CollectedBlockInformation = z.infer<
   typeof collectedBlockInformationSchema
 >;
 
 export const collectRouter = router({
+  uploadCoverImage: adminProcedure
+    .input(
+      z.object({
+        blockID: z.string().min(1),
+        sortOrder: z.number().int().nonnegative(),
+        fileName: z.string().min(1),
+        mimeType: z.string().min(1),
+        dataBase64: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const fileBuffer = Buffer.from(input.dataBase64, 'base64');
+      if (!fileBuffer || fileBuffer.length === 0) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Uploaded file payload is empty or invalid.',
+        });
+      }
+
+      const uploadedImage = await persistUploadedImageToS3({
+        imageBuffer: fileBuffer,
+        mediaType: 'book',
+        mediaId: input.blockID,
+        sortOrder: input.sortOrder,
+        fileName: input.fileName,
+        mimeType: input.mimeType,
+      });
+
+      return { url: uploadedImage.publicPath };
+    }),
   collectMedia: adminProcedure
     .input(
       z.object({

--- a/lib/trpc/routers/database/_.ts
+++ b/lib/trpc/routers/database/_.ts
@@ -20,8 +20,8 @@ import { collectedBlockInformationSchema } from '@/mediacollector/collector-form
 import { allGenres, NO_GENRE_FILTER } from '@/lib/enums/genreEnums';
 import { DATABASE_SORT_OPTIONS } from 'lib/constants/databaseSortOptions';
 import {
-  loadBookImageUrlsById,
-  loadOtherMediaImageUrlsById,
+  loadBookImagesById,
+  loadOtherMediaImagesById,
   replaceBookImageRecords,
   replaceOtherMediaImageRecords,
   resolveAndPersistImageList,
@@ -30,6 +30,13 @@ import { DatabaseSaveEditErrorResponse } from '@/api/api-Errors';
 
 const mediaType = z.enum(['book', 'movie', 'videoGame', 'album']);
 const sortKey = z.enum(DATABASE_SORT_OPTIONS);
+const mediaImageItemSchema = z.object({
+  url: z.string().min(1),
+  selected: z.boolean().optional(),
+  isDefault: z.boolean(),
+  spineColor: z.string().min(1),
+});
+
 const bookEditSchema = z.object({
   id: z.string().optional(),
   title: z.string().min(1),
@@ -37,14 +44,22 @@ const bookEditSchema = z.object({
   pageCount: z.number().nullable(),
   pubYear: z.number().nullable(),
   spineColor: z.string().min(1),
-  imageUrls: z.array(z.string()),
+  images: z.array(mediaImageItemSchema).min(1),
 });
 const otherMediaEditSchema = z.object({
   id: z.string().optional(),
   title: z.string().min(1),
   spineColor: z.string().min(1),
-  imageUrls: z.array(z.string()),
+  images: z.array(mediaImageItemSchema).min(1),
 });
+
+function resolveDisplaySpineColor(
+  images: Array<{ isDefault: boolean; spineColor: string }>,
+  fallbackSpineColor: string,
+) {
+  const defaultImage = images.find((image) => image.isDefault);
+  return defaultImage?.spineColor ?? fallbackSpineColor;
+}
 
 function formatImagePersistenceErrors(
   sourceFailures: Array<{ sourceUrl: string; message: string }>,
@@ -155,14 +170,18 @@ export const databaseRouter = router({
           .leftJoin(genres, eq(genresBooks.genreId, genres.id))
           .where(whereFilter);
 
-        const imageUrlsByBookId = await loadBookImageUrlsById(
+        const imagesByBookId = await loadBookImagesById(
           db,
           rows.map((row) => row.id),
         );
-        const rowsWithResolvedImages = rows.map((row) => ({
-          ...row,
-          imageUrls: imageUrlsByBookId.get(row.id) ?? [],
-        }));
+        const rowsWithResolvedImages = rows.map((row) => {
+          const images = imagesByBookId.get(row.id) ?? [];
+          return {
+            ...row,
+            images,
+            spineColor: resolveDisplaySpineColor(images, row.spineColor),
+          };
+        });
 
         const res: SuccessfulPaginationResponse = {
           message: 'Successful database gather',
@@ -210,14 +229,18 @@ export const databaseRouter = router({
         .from(otherMedia)
         .where(whereFilter);
 
-      const imageUrlsByOtherMediaId = await loadOtherMediaImageUrlsById(
+      const imagesByOtherMediaId = await loadOtherMediaImagesById(
         db,
         rows.map((row) => row.id),
       );
-      const rowsWithResolvedImages = rows.map((row) => ({
-        ...row,
-        imageUrls: imageUrlsByOtherMediaId.get(row.id) ?? [],
-      }));
+      const rowsWithResolvedImages = rows.map((row) => {
+        const images = imagesByOtherMediaId.get(row.id) ?? [];
+        return {
+          ...row,
+          images,
+          spineColor: resolveDisplaySpineColor(images, row.spineColor),
+        };
+      });
 
       const res: SuccessfulPaginationResponse = {
         message: 'Successful database gather',
@@ -286,7 +309,18 @@ export const databaseRouter = router({
           continue;
         }
         const selectedImages = mediaItem.images.filter((img) => img.selected);
+        const imagesToPersist =
+          selectedImages.length > 0
+            ? selectedImages
+            : mediaItem.images.length > 0
+              ? [{ ...mediaItem.images[0], selected: true, isDefault: true }]
+              : [];
         const payload = { ...mediaItem, images: selectedImages };
+        payload.images = imagesToPersist.map((image, index) => ({
+          ...image,
+          isDefault: index === 0,
+          selected: index === 0,
+        }));
         const validatedData =
           collectedBlockInformationSchema.safeParse(payload);
         if (!validatedData.success) {
@@ -311,7 +345,7 @@ export const databaseRouter = router({
                 author: data.blockInfo.author ?? '',
                 pageCount: data.blockInfo.pageCount ?? null,
                 pubYear: data.blockInfo.pubYear ?? null,
-                spineColor: data.blockInfo.spineColor,
+                spineColor: data.images[0]?.spineColor ?? data.blockInfo.spineColor,
               })
               .returning();
 
@@ -336,7 +370,12 @@ export const databaseRouter = router({
 
             const resolvedImages = await resolveAndPersistImageList(
               { mediaType: 'book', mediaId: book.id },
-              data.images.map((img) => img.url),
+              data.images.map((image) => ({
+                url: image.url,
+                isDefault: image.isDefault,
+                spineColor: image.spineColor,
+              })),
+              { defaultSpineColor: data.blockInfo.spineColor, defaultImageIndex: 0 },
             );
             if (resolvedImages.failures.length > 0) {
               await db.delete(books).where(eq(books.id, book.id));
@@ -349,13 +388,23 @@ export const databaseRouter = router({
               continue;
             }
             await replaceBookImageRecords(db, book.id, resolvedImages.images);
-            const imageUrls = resolvedImages.images.map((image) => image.publicPath);
+            const images = resolvedImages.images.map((image) => ({
+              url: image.publicPath,
+              isDefault: image.isDefault,
+              spineColor: image.spineColor,
+              selected: false,
+            }));
+            const persistedSpineColor = resolveDisplaySpineColor(
+              images,
+              data.blockInfo.spineColor,
+            );
 
             results.push({
               message: `${titleRearrange(book.title)} successfully added to database.`,
               actionAttemptItem: {
                 ...book,
-                imageUrls,
+                images,
+                spineColor: persistedSpineColor,
                 genres: data.blockInfo.genres,
                 blockID: data.blockID,
               },
@@ -382,7 +431,7 @@ export const databaseRouter = router({
         const insertData = {
           mediaType: data.type,
           title: titleRearrange(data.blockInfo.title),
-          spineColor: data.blockInfo.spineColor,
+          spineColor: data.images[0]?.spineColor ?? data.blockInfo.spineColor,
         };
         const [savedOtherMedia] = await db
           .insert(otherMedia)
@@ -401,7 +450,12 @@ export const databaseRouter = router({
         } else {
           const resolvedImages = await resolveAndPersistImageList(
             { mediaType: data.type, mediaId: savedOtherMedia.id },
-            data.images.map((img) => img.url),
+            data.images.map((image) => ({
+              url: image.url,
+              isDefault: image.isDefault,
+              spineColor: image.spineColor,
+            })),
+            { defaultSpineColor: data.blockInfo.spineColor, defaultImageIndex: 0 },
           );
           if (resolvedImages.failures.length > 0) {
             await db.delete(otherMedia).where(eq(otherMedia.id, savedOtherMedia.id));
@@ -418,13 +472,23 @@ export const databaseRouter = router({
             savedOtherMedia.id,
             resolvedImages.images,
           );
-          const imageUrls = resolvedImages.images.map((image) => image.publicPath);
+          const images = resolvedImages.images.map((image) => ({
+            url: image.publicPath,
+            isDefault: image.isDefault,
+            spineColor: image.spineColor,
+            selected: false,
+          }));
+          const persistedSpineColor = resolveDisplaySpineColor(
+            images,
+            insertData.spineColor,
+          );
 
           results.push({
             message: `${titleRearrange(insertData.title)} successfully added to database.`,
             actionAttemptItem: {
               ...savedOtherMedia,
-              imageUrls,
+              images,
+              spineColor: persistedSpineColor,
               blockID: data.blockID,
             },
             type: data.type,
@@ -472,7 +536,12 @@ export const databaseRouter = router({
         }
         const resolvedImages = await resolveAndPersistImageList(
           { mediaType: 'book', mediaId: existingBook.id },
-          data.imageUrls,
+          data.images.map((image) => ({
+            url: image.url,
+            isDefault: image.isDefault,
+            spineColor: image.spineColor,
+          })),
+          { defaultSpineColor: data.spineColor },
         );
         if (resolvedImages.failures.length > 0) {
           return createImagePersistenceErrorResponse(
@@ -480,7 +549,13 @@ export const databaseRouter = router({
             resolvedImages.failures,
           );
         }
-        const imageUrls = resolvedImages.images.map((image) => image.publicPath);
+        const images = resolvedImages.images.map((image) => ({
+          url: image.publicPath,
+          isDefault: image.isDefault,
+          spineColor: image.spineColor,
+          selected: false,
+        }));
+        const persistedSpineColor = resolveDisplaySpineColor(images, data.spineColor);
         const [book] = await db
           .update(books)
           .set({
@@ -488,7 +563,7 @@ export const databaseRouter = router({
             author: data.author ?? '',
             pageCount: data.pageCount ?? null,
             pubYear: data.pubYear ?? null,
-            spineColor: data.spineColor,
+            spineColor: persistedSpineColor,
           })
           .where(whereExpression)
           .returning();
@@ -498,7 +573,8 @@ export const databaseRouter = router({
           message: `${titleRearrange(book.title)} successfully edited.`,
           actionAttemptItem: {
             ...book,
-            imageUrls,
+            images,
+            spineColor: persistedSpineColor,
           },
           type,
         };
@@ -535,18 +611,29 @@ export const databaseRouter = router({
       }
       const resolvedImages = await resolveAndPersistImageList(
         { mediaType: type, mediaId: existingOtherMedia.id },
-        data.imageUrls,
+        data.images.map((image) => ({
+          url: image.url,
+          isDefault: image.isDefault,
+          spineColor: image.spineColor,
+        })),
+        { defaultSpineColor: data.spineColor },
       );
       if (resolvedImages.failures.length > 0) {
         return createImagePersistenceErrorResponse(data.title, resolvedImages.failures);
       }
-      const imageUrls = resolvedImages.images.map((image) => image.publicPath);
+      const images = resolvedImages.images.map((image) => ({
+        url: image.publicPath,
+        isDefault: image.isDefault,
+        spineColor: image.spineColor,
+        selected: false,
+      }));
+      const persistedSpineColor = resolveDisplaySpineColor(images, data.spineColor);
       const [savedOtherMedia] = await db
         .update(otherMedia)
         .set({
           mediaType: type,
           title: data.title,
-          spineColor: data.spineColor,
+          spineColor: persistedSpineColor,
         })
         .where(whereExpression)
         .returning();
@@ -560,7 +647,8 @@ export const databaseRouter = router({
         message: `${titleRearrange(savedOtherMedia.title)} successfully edited.`,
         actionAttemptItem: {
           ...savedOtherMedia,
-          imageUrls,
+          images,
+          spineColor: persistedSpineColor,
         },
         type,
       };

--- a/lib/trpc/routers/database/_.ts
+++ b/lib/trpc/routers/database/_.ts
@@ -302,38 +302,37 @@ export const databaseRouter = router({
 
         const data = validatedData.data;
         if (data.type === 'book') {
+          let createdBookId: string | null = null;
           try {
-            const book = await db.transaction(async (tx) => {
-              const [createdBook] = await tx
-                .insert(books)
-                .values({
-                  title: titleRearrange(data.blockInfo.title),
-                  author: data.blockInfo.author ?? '',
-                  pageCount: data.blockInfo.pageCount ?? null,
-                  pubYear: data.blockInfo.pubYear ?? null,
-                  spineColor: data.blockInfo.spineColor,
-                })
-                .returning();
+            const [book] = await db
+              .insert(books)
+              .values({
+                title: titleRearrange(data.blockInfo.title),
+                author: data.blockInfo.author ?? '',
+                pageCount: data.blockInfo.pageCount ?? null,
+                pubYear: data.blockInfo.pubYear ?? null,
+                spineColor: data.blockInfo.spineColor,
+              })
+              .returning();
 
-              if (!createdBook) {
-                throw new Error('Book insertion failed');
-              }
+            if (!book) {
+              throw new Error('Book insertion failed');
+            }
+            createdBookId = book.id;
 
-              for (const genreName of data.blockInfo.genres) {
-                const [genreRow] = await tx
-                  .select()
-                  .from(genres)
-                  .where(eq(genres.genre, genreName));
-                if (!genreRow) {
-                  throw new Error(`Genre "${genreName}" does not exist`);
-                }
-                await tx.insert(genresBooks).values({
-                  bookId: createdBook.id,
-                  genreId: genreRow.id,
-                });
+            for (const genreName of data.blockInfo.genres) {
+              const [genreRow] = await db
+                .select()
+                .from(genres)
+                .where(eq(genres.genre, genreName));
+              if (!genreRow) {
+                throw new Error(`Genre "${genreName}" does not exist`);
               }
-              return createdBook;
-            });
+              await db.insert(genresBooks).values({
+                bookId: book.id,
+                genreId: genreRow.id,
+              });
+            }
 
             const resolvedImages = await resolveAndPersistImageList(
               { mediaType: 'book', mediaId: book.id },
@@ -363,6 +362,9 @@ export const databaseRouter = router({
               type: data.type,
             });
           } catch (error) {
+            if (createdBookId) {
+              await db.delete(books).where(eq(books.id, createdBookId));
+            }
             const message =
               error instanceof Error
                 ? error.message

--- a/lib/trpc/routers/database/actions/search-by-title.ts
+++ b/lib/trpc/routers/database/actions/search-by-title.ts
@@ -4,8 +4,8 @@ import { MediaType } from 'lib/constants/mediaTypes';
 import { titleRearrange } from 'lib/helpers/titleRearrange';
 import { books, otherMedia } from '@/db/schema';
 import {
-  loadBookImageUrlsById,
-  loadOtherMediaImageUrlsById,
+  loadBookImagesById,
+  loadOtherMediaImagesById,
 } from 'lib/media-storage/media-image-records';
 
 export async function searchByTitle(db: Db, type: MediaType, title: string) {
@@ -28,23 +28,23 @@ export async function searchByTitle(db: Db, type: MediaType, title: string) {
   const normalizedResult =
     type === 'book'
       ? await (async () => {
-          const imageUrlsByBookId = await loadBookImageUrlsById(
+          const imagesByBookId = await loadBookImagesById(
             db,
             result.map((row) => row.id),
           );
           return result.map((row) => ({
             ...row,
-            imageUrls: imageUrlsByBookId.get(row.id) ?? [],
+            images: imagesByBookId.get(row.id) ?? [],
           }));
         })()
       : await (async () => {
-          const imageUrlsByOtherMediaId = await loadOtherMediaImageUrlsById(
+          const imagesByOtherMediaId = await loadOtherMediaImagesById(
             db,
             result.map((row) => row.id),
           );
           return result.map((row) => ({
             ...row,
-            imageUrls: imageUrlsByOtherMediaId.get(row.id) ?? [],
+            images: imagesByOtherMediaId.get(row.id) ?? [],
           }));
         })();
   const total = normalizedResult.length;

--- a/lib/trpc/routers/genres/_.ts
+++ b/lib/trpc/routers/genres/_.ts
@@ -11,7 +11,7 @@ import { db as defaultDb } from '@/db/client';
 // interfaces and types
 import { books, genres, genresBooks } from '@/db/schema';
 import { and, asc, desc, eq, isNull, sql } from 'drizzle-orm';
-import { loadBookImageUrlsById } from 'lib/media-storage/media-image-records';
+import { loadBookImagesById } from 'lib/media-storage/media-image-records';
 
 const validSortKeys = ['title', 'pubYear', 'spineColor'] as const;
 type SortKey = (typeof validSortKeys)[number];
@@ -166,13 +166,13 @@ export const genresRouter = router({
         .innerJoin(genres, eq(genres.id, genresBooks.genreId))
         .where(eq(genres.genre, input.genre));
 
-      const imageUrlsByBookId = await loadBookImageUrlsById(
+      const imagesByBookId = await loadBookImagesById(
         db,
         rows.map((row) => row.book.id),
       );
       const paginatedList = rows.map((row) => ({
         ...row.book,
-        imageUrls: imageUrlsByBookId.get(row.book.id) ?? [],
+        images: imagesByBookId.get(row.book.id) ?? [],
       }));
       const res: SuccessfulPaginationResponse = {
         message: 'Successful database gather',
@@ -222,13 +222,13 @@ export const genresRouter = router({
         .leftJoin(genresBooks, eq(genresBooks.bookId, books.id))
         .where(isNull(genresBooks.bookId));
 
-      const imageUrlsByBookId = await loadBookImageUrlsById(
+      const imagesByBookId = await loadBookImagesById(
         db,
         rows.map((row) => row.book.id),
       );
       const paginatedList = rows.map((row) => ({
         ...row.book,
-        imageUrls: imageUrlsByBookId.get(row.book.id) ?? [],
+        images: imagesByBookId.get(row.book.id) ?? [],
       }));
       const res: SuccessfulPaginationResponse = {
         message: 'Successful database gather',


### PR DESCRIPTION
#Summary

Added full multi-cover support for media items by storing per-image isDefault and spineColor metadata in media_image_items, with a migration that backfills existing records.
Introduced a shared MediaImageStrip UI for Media Collector and database views, including selected-cover display, default-cover badges, overflow handling, broken-image fallback, and upload slots.
Added custom book-cover upload support in both Media Collector and database edit flows, persisting uploaded images to S3 alongside collected external covers.
Updated collection, search, pagination, save, and edit routes to load and preserve structured image records instead of treating covers as plain URL arrays.
Fixed PNG export generation so it uses the currently selected image for each title rather than always falling back to the default cover.

#Why
This makes cover handling match the real workflow: a title can have multiple valid covers, and the user needs to choose or upload the one that should appear in the final PNG and be saved for future use. Persisting default status and spine color per image also keeps database records, edits, and generated exports consistent.

#Test Coverage
The branch adds regression coverage for image persistence, collect/database router behavior, Media Collector image upload and fallback UI, database edit image behavior, shared image strip interactions, and selected-image PNG export logic.
